### PR TITLE
fix: prevent color swatches from rendering as squashed ellipses

### DIFF
--- a/crates/ui/src/components/color_picker.rs
+++ b/crates/ui/src/components/color_picker.rs
@@ -82,9 +82,18 @@ pub fn build_color_picker(
 
     // Build 9 GNOME accent toggle buttons
     for (i, &(id, label, hex)) in GNOME_COLORS.iter().enumerate() {
+        // Swatches are circular, so width == height must be enforced
+        // at every layer — GTK widget request, CSS min-width /
+        // min-height, and alignment. When they disagree (e.g. CSS
+        // min-width 24 vs widget width-request 28) and the parent
+        // suffix row stretches, we get a 24x28 ellipse instead.
         let btn = gtk::ToggleButton::builder()
             .width_request(28)
             .height_request(28)
+            .halign(gtk::Align::Center)
+            .valign(gtk::Align::Center)
+            .hexpand(false)
+            .vexpand(false)
             .tooltip_text(label)
             .active(current_id == Some(id))
             .build();
@@ -97,8 +106,8 @@ pub fn build_color_picker(
             ".{css_class} {{ \
                 background: {hex}; \
                 border-radius: 50%; \
-                min-width: 24px; \
-                min-height: 24px; \
+                min-width: 28px; \
+                min-height: 28px; \
                 padding: 0; \
                 border: 2px solid transparent; \
             }} \

--- a/crates/ui/src/components/theme_builder.rs
+++ b/crates/ui/src/components/theme_builder.rs
@@ -1659,11 +1659,14 @@ impl SimpleComponent for ThemeBuilderModel {
                     );
                     let css_provider = gtk::CssProvider::new();
                     css_provider.load_from_string(&format!(
+                        // Match widget request (28x28) and CSS
+                        // minimums so a squeezing parent can't
+                        // produce a 24x28 ellipse — see bug #1.
                         ".{css_class} {{ \
                             background: {hex}; \
                             border-radius: 50%; \
-                            min-width: 24px; \
-                            min-height: 24px; \
+                            min-width: 28px; \
+                            min-height: 28px; \
                             padding: 0; \
                             border: 2px solid transparent; \
                         }} \
@@ -1685,6 +1688,10 @@ impl SimpleComponent for ThemeBuilderModel {
                         let btn = gtk::ToggleButton::builder()
                             .width_request(28)
                             .height_request(28)
+                            .halign(gtk::Align::Center)
+                            .valign(gtk::Align::Center)
+                            .hexpand(false)
+                            .vexpand(false)
                             .tooltip_text(&format!("{hex} \u{2192} {accent_id}"))
                             .build();
                         btn.add_css_class(&format!(


### PR DESCRIPTION
## Summary

- Color accent toggles and wallpaper swatches had conflicting size constraints: `width_request: 28` on the GTK widget but `min-width: 24px` in CSS, with no `halign` pin. When a stretching parent (e.g. `AdwActionRow` suffix) squeezed the button horizontally, the 24px CSS minimum won for width while the 28px height was preserved — producing a 24×28 ellipse.
- Normalised the CSS minimums to 28 and added `halign: Center` + `hexpand: false` on both swatch types so the parent can't stretch them.

## Test plan

- [x] Build + launch: `cargo build --release -p gnomex-ui && /usr/bin/gnome-x`
- [x] Open Theme tab — accent color circles should be perfectly round
- [x] Click *Extract from Wallpaper* — wallpaper swatches should also be round
- [x] Resize the window narrower — circles should stay circular at every width

Closes #1