### PR TITLE
feat(infra): XDG-aware theme resolver + GTK3 override (GXF-010)

### DIFF
--- a/crates/infra/src/filesystem_installer.rs
+++ b/crates/infra/src/filesystem_installer.rs
@@ -1,6 +1,7 @@
 // Copyright 2026 GNOME X Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::theme_paths::{list_all, ResourcePaths};
 use gnomex_app::ports::LocalInstaller;
 use gnomex_app::AppError;
 use gnomex_domain::{ExtensionUuid, ThemeType};
@@ -9,13 +10,18 @@ use std::path::{Path, PathBuf};
 
 /// Concrete adapter: install/uninstall content to the local filesystem.
 ///
-/// Respects XDG directories:
-/// - Extensions: `~/.local/share/gnome-shell/extensions/<uuid>/`
-/// - Themes: `~/.local/share/themes/<name>/`
-/// - Icons/Cursors: `~/.local/share/icons/<name>/`
+/// Install targets (always user-writable):
+/// - Extensions: `$XDG_DATA_HOME/gnome-shell/extensions/<uuid>/`
+/// - Themes: `$XDG_DATA_HOME/themes/<name>/`
+/// - Icons/Cursors: `$XDG_DATA_HOME/icons/<name>/`
+///
+/// List operations walk every path that GNOME searches, not just the
+/// install target — themes under `~/.themes` (legacy), system themes
+/// under `/usr/share/themes`, and all `$XDG_DATA_DIRS` entries. See
+/// [`theme_paths`](crate::theme_paths) for the full resolution model.
 pub struct FilesystemInstaller {
     data_dir: PathBuf,
-    home_dir: PathBuf,
+    paths: ResourcePaths,
 }
 
 impl FilesystemInstaller {
@@ -27,11 +33,10 @@ impl FilesystemInstaller {
                 PathBuf::from(home).join(".local/share")
             });
 
-        let home_dir = directories::BaseDirs::new()
-            .map(|d| d.home_dir().to_owned())
-            .unwrap_or_else(|| PathBuf::from("/tmp"));
-
-        Self { data_dir, home_dir }
+        Self {
+            data_dir,
+            paths: ResourcePaths::from_env(),
+        }
     }
 
     fn extensions_dir(&self) -> PathBuf {
@@ -134,54 +139,27 @@ impl LocalInstaller for FilesystemInstaller {
     }
 
     fn list_installed_themes(&self) -> Result<Vec<String>, AppError> {
-        let mut themes = Self::list_subdirs(&self.themes_dir())?;
-        // Legacy user dir
-        let legacy = self.home_dir.join(".themes");
-        if legacy.exists() {
-            themes.extend(Self::list_subdirs(&legacy)?);
-        }
-        // System themes
-        let system = std::path::Path::new("/usr/share/themes");
-        if system.exists() {
-            themes.extend(Self::list_subdirs(system)?);
-        }
-        themes.sort();
-        themes.dedup();
-        Ok(themes)
+        // Walks XDG_DATA_HOME + ~/.themes + every XDG_DATA_DIRS entry.
+        Ok(list_all(&self.paths.themes()))
     }
 
     fn list_installed_icons(&self) -> Result<Vec<String>, AppError> {
-        let mut icons = Self::list_subdirs(&self.icons_dir())?;
-        let legacy = self.home_dir.join(".icons");
-        if legacy.exists() {
-            icons.extend(Self::list_subdirs(&legacy)?);
-        }
-        // System icons
-        let system = std::path::Path::new("/usr/share/icons");
-        if system.exists() {
-            icons.extend(Self::list_subdirs(system)?);
-        }
-        icons.sort();
-        icons.dedup();
-        Ok(icons)
+        Ok(list_all(&self.paths.icons()))
     }
 
     fn list_installed_cursors(&self) -> Result<Vec<String>, AppError> {
-        let all_icon_dirs = [
-            self.icons_dir(),
-            self.home_dir.join(".icons"),
-            std::path::PathBuf::from("/usr/share/icons"),
-        ];
-        let mut cursors = Vec::new();
-        for dir in &all_icon_dirs {
-            if let Ok(names) = Self::list_subdirs(dir) {
-                for name in names {
-                    if dir.join(&name).join("cursors").is_dir() {
-                        cursors.push(name);
-                    }
-                }
-            }
-        }
+        // Cursors live inside icon-theme dirs but only count when the
+        // theme has a `cursors/` subdir — otherwise it's just icons.
+        let mut cursors: Vec<String> = self
+            .paths
+            .cursors()
+            .iter()
+            .flat_map(|sp| {
+                crate::theme_paths::list_subdirs(&sp.path)
+                    .into_iter()
+                    .filter(move |name| sp.path.join(name).join("cursors").is_dir())
+            })
+            .collect();
         cursors.sort();
         cursors.dedup();
         Ok(cursors)

--- a/crates/infra/src/lib.rs
+++ b/crates/infra/src/lib.rs
@@ -19,6 +19,7 @@ mod ocs_client;
 mod pack_toml_storage;
 pub mod shell_customizer;
 pub mod theme_css;
+pub mod theme_paths;
 mod theme_writer;
 mod vscode_themer;
 

--- a/crates/infra/src/theme_paths.rs
+++ b/crates/infra/src/theme_paths.rs
@@ -1,0 +1,411 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Theme / icon / cursor / GTK-override search-path resolver.
+//!
+//! Canonicalises the full resolution order GNOME honours:
+//!
+//! ```text
+//! Themes:   $XDG_DATA_HOME/themes   (≈ ~/.local/share/themes)
+//!           ~/.themes               (legacy but still read by GTK)
+//!           for dir in $XDG_DATA_DIRS:   $dir/themes
+//!                                (≈ /usr/local/share/themes, /usr/share/themes)
+//! Icons:    $XDG_DATA_HOME/icons   · ~/.icons   · $XDG_DATA_DIRS/icons
+//! Cursors:  (same dirs as Icons; scan each for a `cursors/` subdir)
+//! GTK CSS:  $XDG_CONFIG_HOME/gtk-3.0/gtk.css   (GTK 3 override)
+//!           $XDG_CONFIG_HOME/gtk-4.0/gtk.css   (GTK 4 override)
+//! ```
+//!
+//! Paths are emitted in precedence order (user-writable first). The
+//! first hit wins for resolution; later hits are *shadowed* copies
+//! (see [`resolver::resolve`] for detection).
+//!
+//! See GXF-010 / GXF-012 in the tracker.
+
+use std::path::{Path, PathBuf};
+
+/// A single search-path entry annotated with whether it's user-writable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchPath {
+    pub path: PathBuf,
+    pub origin: SearchOrigin,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchOrigin {
+    /// `$XDG_DATA_HOME` — preferred user-writable location.
+    XdgUserData,
+    /// `~/.themes` / `~/.icons` — legacy user-writable, still honoured
+    /// by GTK for backward compatibility.
+    LegacyUserHome,
+    /// Entries from `$XDG_DATA_DIRS`. Typically system-wide,
+    /// non-writable without elevated privileges.
+    XdgSystem,
+}
+
+impl SearchOrigin {
+    /// True when GNOME X can write here without sudo/pkexec.
+    pub fn is_user_writable(self) -> bool {
+        matches!(self, Self::XdgUserData | Self::LegacyUserHome)
+    }
+}
+
+/// Resolver that enumerates every search path for each resource kind.
+///
+/// Construct with [`ResourcePaths::from_env`] to pick up the live
+/// `$HOME` / `$XDG_DATA_HOME` / `$XDG_DATA_DIRS` / `$XDG_CONFIG_HOME`,
+/// or [`ResourcePaths::explicit`] in tests.
+#[derive(Debug, Clone)]
+pub struct ResourcePaths {
+    home: PathBuf,
+    xdg_data_home: PathBuf,
+    xdg_data_dirs: Vec<PathBuf>,
+    xdg_config_home: PathBuf,
+}
+
+impl ResourcePaths {
+    /// Build from environment variables, applying XDG defaults when
+    /// the variables are unset or empty (per the XDG Base Directory
+    /// Specification §4).
+    pub fn from_env() -> Self {
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_default();
+        let xdg_data_home = std::env::var_os("XDG_DATA_HOME")
+            .filter(|v| !v.is_empty())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".local/share"));
+        let xdg_config_home = std::env::var_os("XDG_CONFIG_HOME")
+            .filter(|v| !v.is_empty())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".config"));
+        let xdg_data_dirs = std::env::var("XDG_DATA_DIRS")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .map(|s| s.split(':').map(PathBuf::from).collect())
+            .unwrap_or_else(|| {
+                // XDG default.
+                vec![
+                    PathBuf::from("/usr/local/share"),
+                    PathBuf::from("/usr/share"),
+                ]
+            });
+        Self { home, xdg_data_home, xdg_data_dirs, xdg_config_home }
+    }
+
+    /// Construct with explicit paths — for tests and deterministic
+    /// composition roots.
+    pub fn explicit(
+        home: impl Into<PathBuf>,
+        xdg_data_home: impl Into<PathBuf>,
+        xdg_data_dirs: Vec<PathBuf>,
+        xdg_config_home: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            home: home.into(),
+            xdg_data_home: xdg_data_home.into(),
+            xdg_data_dirs,
+            xdg_config_home: xdg_config_home.into(),
+        }
+    }
+
+    /// Search paths for GTK themes, in resolution order.
+    pub fn themes(&self) -> Vec<SearchPath> {
+        self.data_backed_paths("themes", Some(".themes"))
+    }
+
+    /// Search paths for icon themes, in resolution order.
+    pub fn icons(&self) -> Vec<SearchPath> {
+        self.data_backed_paths("icons", Some(".icons"))
+    }
+
+    /// Search paths for cursor themes. Cursors use the icon search
+    /// paths but callers filter to entries with a `cursors/` subdir.
+    pub fn cursors(&self) -> Vec<SearchPath> {
+        self.icons()
+    }
+
+    /// Preferred user-writable target for a new theme/icon/cursor
+    /// install. Always returns the `$XDG_DATA_HOME/<subdir>` entry
+    /// since that's what GTK4 and icon-cache tooling prefer today,
+    /// even when the legacy `~/.themes` path exists.
+    pub fn preferred_user_dir(&self, subdir: &str) -> PathBuf {
+        self.xdg_data_home.join(subdir)
+    }
+
+    /// `gtk.css` override paths, ordered GTK4 first because it's the
+    /// primary target today. The GTK3 override is kept so apps still
+    /// running on the older toolkit (legacy or sandboxed Electron
+    /// wrappers) get themed too.
+    pub fn gtk_overrides(&self) -> GtkOverrideFiles {
+        GtkOverrideFiles {
+            gtk4: self.xdg_config_home.join("gtk-4.0/gtk.css"),
+            gtk3: self.xdg_config_home.join("gtk-3.0/gtk.css"),
+        }
+    }
+
+    fn data_backed_paths(
+        &self,
+        subdir: &str,
+        legacy_home_dir: Option<&str>,
+    ) -> Vec<SearchPath> {
+        let mut out = Vec::with_capacity(2 + self.xdg_data_dirs.len());
+        out.push(SearchPath {
+            path: self.xdg_data_home.join(subdir),
+            origin: SearchOrigin::XdgUserData,
+        });
+        if let Some(name) = legacy_home_dir {
+            out.push(SearchPath {
+                path: self.home.join(name),
+                origin: SearchOrigin::LegacyUserHome,
+            });
+        }
+        for dir in &self.xdg_data_dirs {
+            out.push(SearchPath {
+                path: dir.join(subdir),
+                origin: SearchOrigin::XdgSystem,
+            });
+        }
+        out
+    }
+}
+
+/// GTK override file paths (both toolkit generations). See
+/// [`ResourcePaths::gtk_overrides`].
+#[derive(Debug, Clone)]
+pub struct GtkOverrideFiles {
+    pub gtk4: PathBuf,
+    pub gtk3: PathBuf,
+}
+
+/// Utility: list immediate subdirectory names of `dir`, silently
+/// returning an empty list when `dir` doesn't exist or can't be read.
+pub fn list_subdirs(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut names = Vec::new();
+    for entry in entries.flatten() {
+        if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            if let Some(name) = entry.file_name().to_str() {
+                names.push(name.to_owned());
+            }
+        }
+    }
+    names
+}
+
+/// Scan every search path in `paths` and aggregate installed resource
+/// names. Entries whose name appears in more than one path are still
+/// returned exactly once — shadowing detection lives in
+/// [`shadow_map`] (see GXF-012).
+pub fn list_all(paths: &[SearchPath]) -> Vec<String> {
+    let mut all: Vec<String> = paths
+        .iter()
+        .flat_map(|p| list_subdirs(&p.path))
+        .collect();
+    all.sort();
+    all.dedup();
+    all
+}
+
+/// Map each installed resource name to the full list of search paths
+/// it was found in. Names appearing in more than one path are
+/// *shadowed*: the first entry in the Vec wins at resolution time,
+/// later entries are masked. Returned map is unordered; caller can
+/// filter `value.len() > 1` to surface conflicts to the user.
+pub fn shadow_map(
+    paths: &[SearchPath],
+) -> std::collections::BTreeMap<String, Vec<SearchPath>> {
+    let mut map: std::collections::BTreeMap<String, Vec<SearchPath>> =
+        std::collections::BTreeMap::new();
+    for sp in paths {
+        for name in list_subdirs(&sp.path) {
+            map.entry(name).or_default().push(sp.clone());
+        }
+    }
+    map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rp(
+        home: &str,
+        xdg_data_home: &str,
+        xdg_data_dirs: &[&str],
+        xdg_config_home: &str,
+    ) -> ResourcePaths {
+        ResourcePaths::explicit(
+            home,
+            xdg_data_home,
+            xdg_data_dirs.iter().map(PathBuf::from).collect(),
+            xdg_config_home,
+        )
+    }
+
+    #[test]
+    fn themes_order_puts_user_first_legacy_second_system_last() {
+        let r = rp(
+            "/home/user",
+            "/home/user/.local/share",
+            &["/usr/local/share", "/usr/share"],
+            "/home/user/.config",
+        );
+        let paths = r.themes();
+        assert_eq!(paths.len(), 4);
+        assert_eq!(paths[0].path, PathBuf::from("/home/user/.local/share/themes"));
+        assert_eq!(paths[0].origin, SearchOrigin::XdgUserData);
+        assert_eq!(paths[1].path, PathBuf::from("/home/user/.themes"));
+        assert_eq!(paths[1].origin, SearchOrigin::LegacyUserHome);
+        assert_eq!(paths[2].path, PathBuf::from("/usr/local/share/themes"));
+        assert_eq!(paths[2].origin, SearchOrigin::XdgSystem);
+        assert_eq!(paths[3].path, PathBuf::from("/usr/share/themes"));
+        assert_eq!(paths[3].origin, SearchOrigin::XdgSystem);
+    }
+
+    #[test]
+    fn icons_and_cursors_share_the_same_search_dirs() {
+        let r = rp(
+            "/home/user",
+            "/home/user/.local/share",
+            &["/usr/share"],
+            "/home/user/.config",
+        );
+        assert_eq!(r.icons(), r.cursors());
+    }
+
+    #[test]
+    fn gtk_overrides_point_at_canonical_xdg_config_paths() {
+        let r = rp(
+            "/home/user",
+            "/home/user/.local/share",
+            &["/usr/share"],
+            "/home/user/.config",
+        );
+        let g = r.gtk_overrides();
+        assert_eq!(g.gtk4, PathBuf::from("/home/user/.config/gtk-4.0/gtk.css"));
+        assert_eq!(g.gtk3, PathBuf::from("/home/user/.config/gtk-3.0/gtk.css"));
+    }
+
+    #[test]
+    fn origin_user_writable_classification() {
+        assert!(SearchOrigin::XdgUserData.is_user_writable());
+        assert!(SearchOrigin::LegacyUserHome.is_user_writable());
+        assert!(!SearchOrigin::XdgSystem.is_user_writable());
+    }
+
+    #[test]
+    fn preferred_user_dir_is_always_xdg_data_home() {
+        let r = rp(
+            "/h",
+            "/h/.local/share",
+            &["/usr/share"],
+            "/h/.config",
+        );
+        assert_eq!(
+            r.preferred_user_dir("themes"),
+            PathBuf::from("/h/.local/share/themes")
+        );
+    }
+
+    #[test]
+    fn shadow_map_detects_same_theme_in_multiple_paths() {
+        // Build a live tempdir with the same subdir name in two paths.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        std::fs::create_dir_all(a.join("Adwaita")).unwrap();
+        std::fs::create_dir_all(b.join("Adwaita")).unwrap();
+        std::fs::create_dir_all(a.join("OnlyA")).unwrap();
+
+        let paths = vec![
+            SearchPath { path: a.clone(), origin: SearchOrigin::XdgUserData },
+            SearchPath { path: b.clone(), origin: SearchOrigin::XdgSystem },
+        ];
+        let map = shadow_map(&paths);
+        assert_eq!(map["Adwaita"].len(), 2, "Adwaita should be shadowed");
+        assert_eq!(map["OnlyA"].len(), 1);
+        // User-writable path comes first (it's the one that wins).
+        assert_eq!(map["Adwaita"][0].origin, SearchOrigin::XdgUserData);
+    }
+
+    #[test]
+    fn list_all_dedups_across_paths() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        std::fs::create_dir_all(a.join("Adwaita")).unwrap();
+        std::fs::create_dir_all(b.join("Adwaita")).unwrap();
+        let paths = vec![
+            SearchPath { path: a, origin: SearchOrigin::XdgUserData },
+            SearchPath { path: b, origin: SearchOrigin::XdgSystem },
+        ];
+        let names = list_all(&paths);
+        assert_eq!(names, vec!["Adwaita".to_owned()]);
+    }
+
+    #[test]
+    fn xdg_defaults_match_spec_when_env_unset() {
+        // Isolate HOME only — leave XDG_DATA_HOME/CONFIG_HOME/DATA_DIRS
+        // unset so the defaults fire. `from_env` reads lazily so we
+        // have to do this inside a single test context.
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg_data_home = std::env::var_os("XDG_DATA_HOME");
+        let prev_xdg_cfg_home = std::env::var_os("XDG_CONFIG_HOME");
+        let prev_xdg_data_dirs = std::env::var_os("XDG_DATA_DIRS");
+
+        // SAFETY: set/unset around the call; restored in the fn below.
+        unsafe {
+            std::env::set_var("HOME", "/tmp/fake-home");
+            std::env::remove_var("XDG_DATA_HOME");
+            std::env::remove_var("XDG_CONFIG_HOME");
+            std::env::remove_var("XDG_DATA_DIRS");
+        }
+        let r = ResourcePaths::from_env();
+        // Restore before asserting to keep the suite hermetic when
+        // assertions panic.
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_xdg_data_home {
+                Some(v) => std::env::set_var("XDG_DATA_HOME", v),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+            match prev_xdg_cfg_home {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+            match prev_xdg_data_dirs {
+                Some(v) => std::env::set_var("XDG_DATA_DIRS", v),
+                None => std::env::remove_var("XDG_DATA_DIRS"),
+            }
+        }
+
+        assert_eq!(
+            r.gtk_overrides().gtk4,
+            PathBuf::from("/tmp/fake-home/.config/gtk-4.0/gtk.css")
+        );
+        assert_eq!(
+            r.themes()[0].path,
+            PathBuf::from("/tmp/fake-home/.local/share/themes")
+        );
+        // XDG_DATA_DIRS default per spec.
+        let system_paths: Vec<PathBuf> = r
+            .themes()
+            .into_iter()
+            .filter(|p| p.origin == SearchOrigin::XdgSystem)
+            .map(|p| p.path)
+            .collect();
+        assert_eq!(
+            system_paths,
+            vec![
+                PathBuf::from("/usr/local/share/themes"),
+                PathBuf::from("/usr/share/themes"),
+            ]
+        );
+    }
+}

--- a/crates/infra/src/theme_writer.rs
+++ b/crates/infra/src/theme_writer.rs
@@ -1,60 +1,59 @@
 // Copyright 2026 GNOME X Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::theme_paths::{GtkOverrideFiles, ResourcePaths};
 use gnomex_app::ports::ThemeWriter;
 use gnomex_app::AppError;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-const GTK_CSS_PATH: &str = ".config/gtk-4.0/gtk.css";
-const GTK_CSS_BACKUP: &str = ".config/gtk-4.0/gtk.css.gnomex-backup";
-const SHELL_THEME_BASE: &str = ".local/share/themes";
+const BACKUP_SUFFIX: &str = ".gnomex-backup";
+const SHELL_THEME_SUBDIR: &str = "themes";
+const CUSTOM_SHELL_THEME_NAME: &str = "GNOME-X-Custom";
 
 /// Concrete adapter: write theme CSS to the local filesystem.
+///
+/// Writes both the GTK4 override (`gtk-4.0/gtk.css`, primary target)
+/// and the GTK3 override (`gtk-3.0/gtk.css`, for legacy and sandboxed
+/// Chromium/Electron apps that still render under GTK3) on every
+/// `write_gtk_css`. Both files are backed up once before the first
+/// overwrite so `clear_overrides` can restore the user's pre-GNOME-X
+/// state.
+///
+/// Related tracker items: GXF-010 (multi-path resolution).
 pub struct FilesystemThemeWriter {
-    home: PathBuf,
+    paths: ResourcePaths,
+    shell_theme_dir: PathBuf,
 }
 
 impl FilesystemThemeWriter {
     pub fn new() -> Self {
-        let home = std::env::var("HOME")
-            .map(PathBuf::from)
-            .unwrap_or_default();
-        Self { home }
+        let paths = ResourcePaths::from_env();
+        let shell_theme_dir = paths.preferred_user_dir(SHELL_THEME_SUBDIR);
+        Self {
+            paths,
+            shell_theme_dir,
+        }
+    }
+
+    fn gtk_override_files(&self) -> GtkOverrideFiles {
+        self.paths.gtk_overrides()
     }
 }
 
 impl ThemeWriter for FilesystemThemeWriter {
     fn write_gtk_css(&self, css: &str) -> Result<(), AppError> {
-        let path = self.home.join(GTK_CSS_PATH);
-        let backup = self.home.join(GTK_CSS_BACKUP);
-
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| AppError::Settings(format!("mkdir: {e}")))?;
+        // Both GTK4 (primary) and GTK3 (for legacy / sandboxed apps
+        // that still render on the older toolkit) get the same CSS.
+        // Each path is independently backed up once.
+        let targets = self.gtk_override_files();
+        for path in [&targets.gtk4, &targets.gtk3] {
+            write_gtk_override(path, css)?;
         }
-
-        // Back up existing gtk.css if it wasn't written by us and no backup exists yet
-        if path.exists() && !backup.exists() {
-            if let Ok(content) = std::fs::read_to_string(&path) {
-                if !content.contains("GNOME X") {
-                    std::fs::copy(&path, &backup).ok();
-                    tracing::info!("backed up existing gtk.css");
-                }
-            }
-        }
-
-        std::fs::write(&path, css)
-            .map_err(|e| AppError::Settings(format!("write gtk.css: {e}")))?;
-        tracing::info!("wrote GTK CSS to {}", path.display());
         Ok(())
     }
 
     fn write_shell_css(&self, css: &str, theme_name: &str) -> Result<(), AppError> {
-        let dir = self
-            .home
-            .join(SHELL_THEME_BASE)
-            .join(theme_name)
-            .join("gnome-shell");
+        let dir = self.shell_theme_dir.join(theme_name).join("gnome-shell");
         std::fs::create_dir_all(&dir)
             .map_err(|e| AppError::Settings(format!("mkdir: {e}")))?;
         std::fs::write(dir.join("gnome-shell.css"), css)
@@ -64,20 +63,179 @@ impl ThemeWriter for FilesystemThemeWriter {
     }
 
     fn clear_overrides(&self) -> Result<(), AppError> {
-        let gtk_path = self.home.join(GTK_CSS_PATH);
-        let backup = self.home.join(GTK_CSS_BACKUP);
-
-        // Restore the user's original gtk.css if we backed it up
-        if backup.exists() {
-            std::fs::rename(&backup, &gtk_path).ok();
-            tracing::info!("restored original gtk.css from backup");
-        } else {
-            let _ = std::fs::remove_file(&gtk_path);
+        let targets = self.gtk_override_files();
+        for path in [&targets.gtk4, &targets.gtk3] {
+            restore_or_remove_gtk_override(path);
         }
-
-        let custom_dir = self.home.join(SHELL_THEME_BASE).join("GNOME-X-Custom");
+        let custom_dir = self.shell_theme_dir.join(CUSTOM_SHELL_THEME_NAME);
         let _ = std::fs::remove_dir_all(custom_dir);
         tracing::info!("cleared theme overrides");
         Ok(())
+    }
+}
+
+/// Write `css` to `path`, first backing up any pre-existing file not
+/// authored by GNOME X.
+fn write_gtk_override(path: &Path, css: &str) -> Result<(), AppError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| AppError::Settings(format!("mkdir {}: {e}", parent.display())))?;
+    }
+    let backup = backup_path(path);
+    if path.exists() && !backup.exists() {
+        if let Ok(content) = std::fs::read_to_string(path) {
+            if !content.contains("GNOME X") {
+                std::fs::copy(path, &backup).ok();
+                tracing::info!("backed up existing {}", path.display());
+            }
+        }
+    }
+    std::fs::write(path, css)
+        .map_err(|e| AppError::Settings(format!("write {}: {e}", path.display())))?;
+    tracing::info!("wrote GTK CSS to {}", path.display());
+    Ok(())
+}
+
+/// Restore the user's original override from its backup, or remove
+/// our copy if no backup exists (meaning the user didn't have one
+/// pre-GNOME-X).
+fn restore_or_remove_gtk_override(path: &Path) {
+    let backup = backup_path(path);
+    if backup.exists() {
+        if std::fs::rename(&backup, path).is_ok() {
+            tracing::info!("restored {} from backup", path.display());
+        }
+    } else {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+fn backup_path(p: &Path) -> PathBuf {
+    let mut s = p.as_os_str().to_owned();
+    s.push(BACKUP_SUFFIX);
+    PathBuf::from(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gnomex_app::ports::ThemeWriter;
+    use tempfile::TempDir;
+
+    fn tmp_writer(root: &Path) -> FilesystemThemeWriter {
+        FilesystemThemeWriter {
+            paths: ResourcePaths::explicit(
+                root,
+                root.join(".local/share"),
+                vec![],
+                root.join(".config"),
+            ),
+            shell_theme_dir: root.join(".local/share/themes"),
+        }
+    }
+
+    #[test]
+    fn write_gtk_css_creates_both_gtk3_and_gtk4_files() {
+        let dir = TempDir::new().unwrap();
+        let writer = tmp_writer(dir.path());
+
+        writer.write_gtk_css("/* test */").unwrap();
+
+        let gtk4 = dir.path().join(".config/gtk-4.0/gtk.css");
+        let gtk3 = dir.path().join(".config/gtk-3.0/gtk.css");
+        assert!(gtk4.exists(), "missing {}", gtk4.display());
+        assert!(gtk3.exists(), "missing {}", gtk3.display());
+        assert_eq!(std::fs::read_to_string(&gtk4).unwrap(), "/* test */");
+        assert_eq!(std::fs::read_to_string(&gtk3).unwrap(), "/* test */");
+    }
+
+    #[test]
+    fn first_write_backs_up_user_authored_gtk_css() {
+        let dir = TempDir::new().unwrap();
+        let writer = tmp_writer(dir.path());
+
+        let gtk4 = dir.path().join(".config/gtk-4.0/gtk.css");
+        std::fs::create_dir_all(gtk4.parent().unwrap()).unwrap();
+        std::fs::write(&gtk4, "/* user-authored */").unwrap();
+
+        writer.write_gtk_css("/* gnome-x */").unwrap();
+
+        let backup = dir
+            .path()
+            .join(".config/gtk-4.0/gtk.css.gnomex-backup");
+        assert!(backup.exists(), "expected backup at {}", backup.display());
+        assert_eq!(
+            std::fs::read_to_string(&backup).unwrap(),
+            "/* user-authored */"
+        );
+    }
+
+    #[test]
+    fn writer_does_not_back_up_its_own_output() {
+        let dir = TempDir::new().unwrap();
+        let writer = tmp_writer(dir.path());
+
+        // Seed with a file that looks like it's ours.
+        let gtk4 = dir.path().join(".config/gtk-4.0/gtk.css");
+        std::fs::create_dir_all(gtk4.parent().unwrap()).unwrap();
+        std::fs::write(&gtk4, "/* GNOME X — Shell overrides */").unwrap();
+
+        writer.write_gtk_css("/* new */").unwrap();
+        let backup = dir
+            .path()
+            .join(".config/gtk-4.0/gtk.css.gnomex-backup");
+        assert!(!backup.exists(), "should not back up our own output");
+    }
+
+    #[test]
+    fn clear_overrides_restores_backup_when_present() {
+        let dir = TempDir::new().unwrap();
+        let writer = tmp_writer(dir.path());
+
+        let gtk4 = dir.path().join(".config/gtk-4.0/gtk.css");
+        std::fs::create_dir_all(gtk4.parent().unwrap()).unwrap();
+        std::fs::write(&gtk4, "/* user-authored */").unwrap();
+
+        writer.write_gtk_css("/* gnome-x */").unwrap();
+        writer.clear_overrides().unwrap();
+
+        // Backup should be gone, gtk.css should hold the original.
+        assert_eq!(
+            std::fs::read_to_string(&gtk4).unwrap(),
+            "/* user-authored */"
+        );
+        assert!(
+            !dir.path()
+                .join(".config/gtk-4.0/gtk.css.gnomex-backup")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn clear_overrides_removes_file_when_no_backup() {
+        let dir = TempDir::new().unwrap();
+        let writer = tmp_writer(dir.path());
+
+        // No prior user file; writer writes its own, then clears.
+        writer.write_gtk_css("/* gnome-x */").unwrap();
+        writer.clear_overrides().unwrap();
+
+        assert!(!dir.path().join(".config/gtk-4.0/gtk.css").exists());
+        assert!(!dir.path().join(".config/gtk-3.0/gtk.css").exists());
+    }
+
+    #[test]
+    fn write_shell_css_creates_custom_theme_dir() {
+        let dir = TempDir::new().unwrap();
+        let writer = tmp_writer(dir.path());
+
+        writer
+            .write_shell_css("/* shell */", "GNOME-X-Custom")
+            .unwrap();
+
+        let css = dir
+            .path()
+            .join(".local/share/themes/GNOME-X-Custom/gnome-shell/gnome-shell.css");
+        assert!(css.exists(), "missing {}", css.display());
     }
 }


### PR DESCRIPTION
## Summary

- New \`crates/infra/src/theme_paths.rs\` resolver that walks the full XDG path set for themes / icons / cursors, plus both GTK3 and GTK4 override paths
- Each path is annotated with its \`SearchOrigin\` (\`XdgUserData\`, \`LegacyUserHome\`, \`XdgSystem\`) so callers can tell user-writable from system locations
- \`FilesystemInstaller\` now lists installed resources through the resolver — previously it hard-coded three paths per function and missed \`\$XDG_DATA_DIRS\` entries
- \`FilesystemThemeWriter\` now writes the GTK 3 override in addition to the GTK 4 one, with independent backups and clean restore on \`clear_overrides()\`. GTK 3 is necessary for Chromium/Electron flatpaks and legacy GNOME apps that still render on the older toolkit
- \`shadow_map()\` helper lays the foundation for GXF-012 (shadowing detection)

## Test plan

- [x] \`cargo test --workspace\` — 14 new tests pass (112 total, was 98)
- [x] Build + run: \`cargo build --release -p gnomex-ui\`
- [x] Apply a theme from the Theme tab — both \`~/.config/gtk-4.0/gtk.css\` and \`~/.config/gtk-3.0/gtk.css\` should be created
- [x] Inspect: \`ls -la ~/.config/gtk-3.0/\`
- [x] Reset theme — both files should be restored to their pre-GNOME-X state (or removed if the user had none)

Closes #5