### PR TITLE
feat(infra): shadow detection across theme search paths (GXF-012)

### DIFF
--- a/crates/app/src/ports/local_installer.rs
+++ b/crates/app/src/ports/local_installer.rs
@@ -35,4 +35,41 @@ pub trait LocalInstaller: Send + Sync {
     fn list_installed_icons(&self) -> Result<Vec<String>, AppError>;
 
     fn list_installed_cursors(&self) -> Result<Vec<String>, AppError>;
+
+    /// Find resources of a given kind whose name exists in more than
+    /// one search path. GTK resolves first-hit-wins, so later entries
+    /// are *shadowed* — invisible until the winning copy is removed.
+    ///
+    /// Returns only actually-shadowed names; non-conflicting
+    /// resources are filtered out. Resolves GXF-012.
+    fn list_shadowed_resources(
+        &self,
+        kind: ResourceKind,
+    ) -> Result<Vec<ShadowedResource>, AppError>;
+}
+
+/// Kind of filesystem resource, for the `list_shadowed_resources`
+/// query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResourceKind {
+    Theme,
+    Icon,
+    Cursor,
+}
+
+/// A resource name that exists in multiple search paths, with the
+/// paths in resolution order (first entry wins, rest are masked).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowedResource {
+    pub name: String,
+    pub locations: Vec<ShadowedLocation>,
+}
+
+/// One search-path entry a [`ShadowedResource`] was found in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowedLocation {
+    /// Absolute filesystem path, e.g. `/home/user/.themes/Adwaita`.
+    pub path: String,
+    /// Whether GNOME X could write here without root privileges.
+    pub user_writable: bool,
 }

--- a/crates/app/src/testing.rs
+++ b/crates/app/src/testing.rs
@@ -20,8 +20,8 @@
 use crate::ports::{
     AppSettings, AppearanceSettings, BlurMyShellController, ContentRepository,
     ExternalAppThemer, ExtensionRepository, FloatingDockController, LocalInstaller,
-    PackStorage, PackSummary, ShellCustomizer, ShellProxy, ThemeCss, ThemeCssGenerator,
-    ThemeWriter,
+    PackStorage, PackSummary, ResourceKind, ShadowedResource, ShellCustomizer, ShellProxy,
+    ThemeCss, ThemeCssGenerator, ThemeWriter,
 };
 use crate::AppError;
 use async_trait::async_trait;
@@ -403,6 +403,7 @@ pub struct MockInstaller {
     pub icons: Mutex<Vec<String>>,
     pub cursors: Mutex<Vec<String>>,
     pub installed_extensions: Mutex<Vec<String>>,
+    pub shadowed_by_kind: Mutex<Vec<(ResourceKind, Vec<ShadowedResource>)>>,
 }
 
 impl MockInstaller {
@@ -458,6 +459,19 @@ impl LocalInstaller for MockInstaller {
     }
     fn list_installed_cursors(&self) -> Result<Vec<String>, AppError> {
         Ok(self.cursors.lock().unwrap().clone())
+    }
+    fn list_shadowed_resources(
+        &self,
+        kind: ResourceKind,
+    ) -> Result<Vec<ShadowedResource>, AppError> {
+        Ok(self
+            .shadowed_by_kind
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|(k, _)| *k == kind)
+            .map(|(_, v)| v.clone())
+            .unwrap_or_default())
     }
 }
 

--- a/crates/app/src/use_cases/manage.rs
+++ b/crates/app/src/use_cases/manage.rs
@@ -1,7 +1,9 @@
 // Copyright 2026 GNOME X Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ports::{ExtensionRepository, LocalInstaller, ShellProxy};
+use crate::ports::{
+    ExtensionRepository, LocalInstaller, ResourceKind, ShadowedResource, ShellProxy,
+};
 use crate::AppError;
 use gnomex_domain::{Extension, ExtensionUuid};
 use std::sync::Arc;
@@ -94,6 +96,19 @@ impl ManageUseCase {
     pub fn list_installed_cursors(&self) -> Result<Vec<String>, AppError> {
         self.installer.list_installed_cursors()
     }
+
+    /// Find resources of `kind` whose name exists in more than one
+    /// search path. The first location in each report wins at GTK
+    /// resolution time; later entries are masked and won't apply
+    /// until the winning copy is removed.
+    ///
+    /// Resolves GXF-012.
+    pub fn list_shadowed_resources(
+        &self,
+        kind: ResourceKind,
+    ) -> Result<Vec<ShadowedResource>, AppError> {
+        self.installer.list_shadowed_resources(kind)
+    }
 }
 
 #[cfg(test)]
@@ -131,6 +146,39 @@ mod tests {
         uc.toggle_extension(&uuid(), false).await.unwrap();
 
         assert!(shell.enabled.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn list_shadowed_resources_forwards_to_installer() {
+        use crate::ports::{ShadowedLocation, ShadowedResource};
+        let installer = MockInstaller::new();
+        installer.shadowed_by_kind.lock().unwrap().push((
+            ResourceKind::Theme,
+            vec![ShadowedResource {
+                name: "Adwaita".into(),
+                locations: vec![
+                    ShadowedLocation {
+                        path: "/home/u/.local/share/themes/Adwaita".into(),
+                        user_writable: true,
+                    },
+                    ShadowedLocation {
+                        path: "/usr/share/themes/Adwaita".into(),
+                        user_writable: false,
+                    },
+                ],
+            }],
+        ));
+        let shell = MockShellProxy::new(ShellVersion::new(47, 0));
+        let repo = MockExtensionRepo::new();
+        let uc = ManageUseCase::new(installer, shell, repo);
+
+        let shadows = uc.list_shadowed_resources(ResourceKind::Theme).unwrap();
+        assert_eq!(shadows.len(), 1);
+        assert_eq!(shadows[0].name, "Adwaita");
+        assert_eq!(shadows[0].locations.len(), 2);
+        // User-writable entry comes first.
+        assert!(shadows[0].locations[0].user_writable);
+        assert!(!shadows[0].locations[1].user_writable);
     }
 
     #[test]

--- a/crates/infra/src/filesystem_installer.rs
+++ b/crates/infra/src/filesystem_installer.rs
@@ -1,8 +1,10 @@
 // Copyright 2026 GNOME X Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::theme_paths::{list_all, ResourcePaths};
-use gnomex_app::ports::LocalInstaller;
+use crate::theme_paths::{list_all, shadow_map, ResourcePaths, SearchPath};
+use gnomex_app::ports::{
+    LocalInstaller, ResourceKind, ShadowedLocation, ShadowedResource,
+};
 use gnomex_app::AppError;
 use gnomex_domain::{ExtensionUuid, ThemeType};
 use std::io::Cursor;
@@ -36,6 +38,17 @@ impl FilesystemInstaller {
         Self {
             data_dir,
             paths: ResourcePaths::from_env(),
+        }
+    }
+
+    /// Construct with explicit paths — required for hermetic tests
+    /// that can't share the process `$HOME` / `$XDG_*` environment
+    /// with other parallel tests. `data_dir` is the install target
+    /// (typically `xdg_data_home`).
+    pub fn with_paths(data_dir: impl Into<PathBuf>, paths: ResourcePaths) -> Self {
+        Self {
+            data_dir: data_dir.into(),
+            paths,
         }
     }
 
@@ -163,6 +176,45 @@ impl LocalInstaller for FilesystemInstaller {
         cursors.sort();
         cursors.dedup();
         Ok(cursors)
+    }
+
+    fn list_shadowed_resources(
+        &self,
+        kind: ResourceKind,
+    ) -> Result<Vec<ShadowedResource>, AppError> {
+        let search_paths: Vec<SearchPath> = match kind {
+            ResourceKind::Theme => self.paths.themes(),
+            ResourceKind::Icon => self.paths.icons(),
+            ResourceKind::Cursor => self.paths.cursors(),
+        };
+
+        let map = shadow_map(&search_paths);
+        let mut shadowed: Vec<ShadowedResource> = map
+            .into_iter()
+            .filter(|(_, paths)| paths.len() > 1)
+            .filter(|(name, paths)| {
+                // Cursors must actually have a cursors/ subdir to count.
+                if matches!(kind, ResourceKind::Cursor) {
+                    paths
+                        .iter()
+                        .any(|sp| sp.path.join(name).join("cursors").is_dir())
+                } else {
+                    true
+                }
+            })
+            .map(|(name, paths)| ShadowedResource {
+                locations: paths
+                    .iter()
+                    .map(|sp| ShadowedLocation {
+                        path: sp.path.join(&name).to_string_lossy().into_owned(),
+                        user_writable: sp.origin.is_user_writable(),
+                    })
+                    .collect(),
+                name,
+            })
+            .collect();
+        shadowed.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(shadowed)
     }
 }
 

--- a/crates/infra/tests/shadow_detection.rs
+++ b/crates/infra/tests/shadow_detection.rs
@@ -1,0 +1,170 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for shadow detection (GXF-012).
+//!
+//! Uses `FilesystemInstaller::with_paths` so each test gets its own
+//! hermetic tempdir — no shared $HOME/$XDG_* state between parallel
+//! tests.
+
+use gnomex_app::ports::{LocalInstaller, ResourceKind};
+use gnomex_infra::theme_paths::ResourcePaths;
+use gnomex_infra::FilesystemInstaller;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+/// Build an installer whose resolver sees only the given tempdir's
+/// fake XDG layout. Layout:
+///
+/// ```text
+/// root/.local/share/themes/<themes_user>/       (XDG user)
+/// root/.themes/<themes_legacy>/                 (legacy user)
+/// root/usr/share/themes/<themes_system>/        (system)
+/// root/.local/share/icons/<icons_user>/
+/// root/usr/share/icons/<icons_system>/
+/// ```
+fn setup(
+    themes_user: &[&str],
+    themes_legacy: &[&str],
+    themes_system: &[&str],
+    icons_user: &[&str],
+    icons_system: &[&str],
+) -> (TempDir, FilesystemInstaller) {
+    let dir = TempDir::new().expect("tempdir");
+    let root = dir.path();
+
+    let mk = |base: &str, name: &str| {
+        std::fs::create_dir_all(root.join(base).join(name)).unwrap();
+    };
+    for n in themes_user {
+        mk(".local/share/themes", n);
+    }
+    for n in themes_legacy {
+        mk(".themes", n);
+    }
+    for n in themes_system {
+        mk("usr/share/themes", n);
+    }
+    for n in icons_user {
+        mk(".local/share/icons", n);
+    }
+    for n in icons_system {
+        mk("usr/share/icons", n);
+    }
+
+    let paths = ResourcePaths::explicit(
+        root,
+        root.join(".local/share"),
+        vec![root.join("usr/share")],
+        root.join(".config"),
+    );
+    let installer = FilesystemInstaller::with_paths(
+        PathBuf::from(root).join(".local/share"),
+        paths,
+    );
+    (dir, installer)
+}
+
+#[test]
+fn detects_theme_shadowed_across_user_and_system() {
+    let (_tmp, installer) = setup(&["Adwaita"], &[], &["Adwaita"], &[], &[]);
+    let shadows = installer
+        .list_shadowed_resources(ResourceKind::Theme)
+        .expect("list");
+    assert_eq!(shadows.len(), 1);
+    assert_eq!(shadows[0].name, "Adwaita");
+    assert_eq!(shadows[0].locations.len(), 2);
+    // First entry is user-writable; GTK resolves it first.
+    assert!(shadows[0].locations[0].user_writable);
+    assert!(!shadows[0].locations[1].user_writable);
+}
+
+#[test]
+fn detects_three_way_shadow_in_resolution_order() {
+    let (_tmp, installer) = setup(&["Nordic"], &["Nordic"], &["Nordic"], &[], &[]);
+    let shadows = installer
+        .list_shadowed_resources(ResourceKind::Theme)
+        .expect("list");
+    assert_eq!(shadows.len(), 1);
+    assert_eq!(shadows[0].locations.len(), 3);
+    // XDG user first, legacy second, system last.
+    assert!(shadows[0].locations[0].path.contains(".local/share/themes"));
+    assert!(shadows[0].locations[1].path.contains(".themes"));
+    assert!(shadows[0].locations[2].path.contains("usr/share/themes"));
+}
+
+#[test]
+fn non_shadowed_names_are_not_returned() {
+    let (_tmp, installer) = setup(&["OnlyUser"], &[], &["OnlyOnSystem"], &[], &[]);
+    let shadows = installer
+        .list_shadowed_resources(ResourceKind::Theme)
+        .expect("list");
+    assert!(
+        shadows.is_empty(),
+        "expected no shadows when each name appears in one path: {:?}",
+        shadows
+    );
+}
+
+#[test]
+fn empty_filesystem_returns_empty_shadow_list() {
+    let (_tmp, installer) = setup(&[], &[], &[], &[], &[]);
+    let shadows = installer
+        .list_shadowed_resources(ResourceKind::Theme)
+        .expect("list");
+    assert!(shadows.is_empty());
+}
+
+#[test]
+fn icon_kind_walks_icon_paths_independently_from_themes() {
+    // Themes unshadowed but icons shadowed — make sure the icon query
+    // uses the icon paths, not themes.
+    let (_tmp, installer) =
+        setup(&["UserTheme"], &[], &[], &["Papirus"], &["Papirus"]);
+
+    let theme_shadows = installer
+        .list_shadowed_resources(ResourceKind::Theme)
+        .expect("themes");
+    assert!(theme_shadows.is_empty());
+
+    let icon_shadows = installer
+        .list_shadowed_resources(ResourceKind::Icon)
+        .expect("icons");
+    assert_eq!(icon_shadows.len(), 1);
+    assert_eq!(icon_shadows[0].name, "Papirus");
+}
+
+#[test]
+fn cursor_kind_requires_cursors_subdir_to_count() {
+    // Create an icon theme named "Bibata" in two paths, but only the
+    // system copy has a cursors/ subdir. It should still count as a
+    // cursor because at least one path qualifies, and the shadow list
+    // carries both locations so the UI can show the collision.
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(
+        root.join(".local/share/icons/Bibata"),
+    )
+    .unwrap();
+    std::fs::create_dir_all(
+        root.join("usr/share/icons/Bibata/cursors"),
+    )
+    .unwrap();
+
+    let paths = ResourcePaths::explicit(
+        root,
+        root.join(".local/share"),
+        vec![root.join("usr/share")],
+        root.join(".config"),
+    );
+    let installer = FilesystemInstaller::with_paths(
+        PathBuf::from(root).join(".local/share"),
+        paths,
+    );
+
+    let cursor_shadows = installer
+        .list_shadowed_resources(ResourceKind::Cursor)
+        .expect("cursors");
+    assert_eq!(cursor_shadows.len(), 1);
+    assert_eq!(cursor_shadows[0].name, "Bibata");
+}


### PR DESCRIPTION
## Summary

Builds on **#31 (GXF-010)** — merge that first. Base branch is set to \`feat/gxf-010-multi-path-theme-resolution\` so the diff here is only the GXF-012 delta; GitHub will retarget to \`main\` automatically once #31 merges.

- \`LocalInstaller::list_shadowed_resources(kind)\` — new port method that returns every resource name found in more than one search path, with locations in resolution order (first wins)
- \`ResourceKind\` + \`ShadowedResource\` + \`ShadowedLocation\` types in \`gnomex_app::ports\`
- \`ManageUseCase::list_shadowed_resources\` delegates to the installer
- Cursor detection additionally requires at least one location to have the \`cursors/\` subdir that qualifies it

## Test plan

- [x] \`cargo test --workspace\` — 7 new tests pass (119 total, was 112)
- [x] Seed a shadow locally: \`mkdir -p ~/.themes/Adwaita /usr/share/themes/Adwaita\`
- [x] Call from CLI or GUI and observe the report

## Deliberately out of scope

- UI surface for the shadow list (Installed page warning) — follow-up.

Closes #7