### PR TITLE
feat: add Sidebar controls and Nautilus CSS fixture

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -14,7 +14,7 @@ use gnomex_app::ports::{ShellCustomizer, ShellProxy};
 use gnomex_app::use_cases::{ApplyThemeUseCase, CustomizeShellUseCase, PacksUseCase};
 use gnomex_domain::{
     DashSpec, ForegroundSpec, HeaderbarSpec, HexColor, InsetSpec, NotificationSpec, Opacity,
-    PanelSpec, Radius, StatusColorSpec, ThemeSpec, TintSpec, WindowFrameSpec,
+    PanelSpec, Radius, SidebarSpec, StatusColorSpec, ThemeSpec, TintSpec, WindowFrameSpec,
 };
 use gnomex_infra::{
     ChromiumThemer, DbusShellProxy, EgoClient, FilesystemInstaller, FilesystemThemeWriter,
@@ -344,6 +344,18 @@ fn build_spec_from_gsettings() -> Result<ThemeSpec> {
             combo_inset: app.boolean("tb-combo-inset"),
         },
         foreground: ForegroundSpec::default(),
+        sidebar: SidebarSpec {
+            opacity: Opacity::from_fraction(app.double("tb-sidebar-opacity"))?,
+            fg_override: {
+                let raw = app.string("tb-sidebar-fg-override").to_string();
+                let trimmed = raw.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(HexColor::new(trimmed)?)
+                }
+            },
+        },
         status_colors: StatusColorSpec::default(),
         notifications: NotificationSpec {
             radius: Radius::new(app.double("tb-notification-radius"))?,

--- a/crates/domain/src/theme_spec.rs
+++ b/crates/domain/src/theme_spec.rs
@@ -142,7 +142,29 @@ pub struct ForegroundSpec {
     pub view_fg: Option<HexColor>,
     pub headerbar_fg: Option<HexColor>,
     pub headerbar_border: Option<HexColor>,
-    pub sidebar_fg: Option<HexColor>,
+}
+
+/// Sidebar-specific controls. Nautilus, Files, Disks, Settings, and any
+/// AdwOverlaySplitView app render a left nav sidebar; this spec groups
+/// the knobs that govern it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SidebarSpec {
+    /// Background opacity. 1.0 = fully opaque (default Adwaita
+    /// behaviour); < 1.0 wraps `sidebar_bg_color` in `alpha()` so the
+    /// wallpaper or compositor blur shows through.
+    pub opacity: Opacity,
+    /// Optional foreground override for sidebar text. `None` keeps the
+    /// Adwaita default `sidebar_fg_color`.
+    pub fg_override: Option<HexColor>,
+}
+
+impl Default for SidebarSpec {
+    fn default() -> Self {
+        Self {
+            opacity: Opacity(1.0),
+            fg_override: None,
+        }
+    }
 }
 
 /// Semantic status color overrides (None = use Adwaita defaults).
@@ -177,6 +199,7 @@ pub struct ThemeSpec {
     pub window_frame: WindowFrameSpec,
     pub insets: InsetSpec,
     pub foreground: ForegroundSpec,
+    pub sidebar: SidebarSpec,
     pub status_colors: StatusColorSpec,
     pub notifications: NotificationSpec,
     pub overview_blur: bool,
@@ -215,6 +238,7 @@ impl ThemeSpec {
                 combo_inset: true,
             },
             foreground: ForegroundSpec::default(),
+            sidebar: SidebarSpec::default(),
             status_colors: StatusColorSpec::default(),
             notifications: NotificationSpec {
                 radius: Radius(12.0),

--- a/crates/infra/src/theme_css/common.rs
+++ b/crates/infra/src/theme_css/common.rs
@@ -9,6 +9,14 @@ use gnomex_domain::{color::blend, HexColor, ThemeSpec};
 /// This is identical across GNOME versions since it targets GTK, not Shell.
 pub fn gtk_tint_css(spec: &ThemeSpec) -> String {
     let tint_pct = spec.tint.intensity.as_fraction();
+    let sidebar_alpha = spec.sidebar.opacity.as_fraction();
+
+    let tl = tint_pct + 0.025;
+    let tcl = tint_pct * 0.6;
+    let td = tint_pct;
+
+    let sidebar_light = sidebar_color_expr(&format!("mix(#ebebed, @accent_bg_color, {tl})"), sidebar_alpha);
+    let sidebar_dark = sidebar_color_expr(&format!("mix(#2e2e32, @accent_bg_color, {td})"), sidebar_alpha);
 
     format!(
         r#"/* Accent-tinted surfaces */
@@ -20,7 +28,7 @@ pub fn gtk_tint_css(spec: &ThemeSpec) -> String {
     @define-color popover_bg_color mix(#ffffff, @accent_bg_color, {tl});
     @define-color dialog_bg_color mix(#fafafb, @accent_bg_color, {tl});
     @define-color card_bg_color mix(#ffffff, @accent_bg_color, {tcl});
-    @define-color sidebar_bg_color mix(#ebebed, @accent_bg_color, {tl});
+    @define-color sidebar_bg_color {sidebar_light};
 }}
 
 @media (prefers-color-scheme: dark) {{
@@ -31,13 +39,21 @@ pub fn gtk_tint_css(spec: &ThemeSpec) -> String {
     @define-color popover_bg_color mix(#36363a, @accent_bg_color, {td});
     @define-color dialog_bg_color mix(#36363a, @accent_bg_color, {td});
     @define-color card_bg_color mix(rgba(255, 255, 255, 0.08), @accent_bg_color, {td});
-    @define-color sidebar_bg_color mix(#2e2e32, @accent_bg_color, {td});
+    @define-color sidebar_bg_color {sidebar_dark};
 }}
 "#,
-        tl = tint_pct + 0.025,
-        tcl = tint_pct * 0.6,
-        td = tint_pct,
     )
+}
+
+/// Wrap a sidebar background expression in `alpha()` iff the user has
+/// dialed opacity below fully opaque. Emitting the raw `mix()` when
+/// opacity == 1.0 keeps the generated CSS readable.
+fn sidebar_color_expr(mix_expr: &str, opacity: f64) -> String {
+    if opacity >= 0.999 {
+        mix_expr.to_string()
+    } else {
+        format!("alpha({mix_expr}, {opacity:.3})")
+    }
 }
 
 /// Generate border-radius rules for GTK4 elements.
@@ -142,7 +158,7 @@ pub fn gtk_color_overrides_css(spec: &ThemeSpec) -> String {
     css.push_str(&color_line("view_fg_color", &fg.view_fg));
     css.push_str(&color_line("headerbar_fg_color", &fg.headerbar_fg));
     css.push_str(&color_line("headerbar_border_color", &fg.headerbar_border));
-    css.push_str(&color_line("sidebar_fg_color", &fg.sidebar_fg));
+    css.push_str(&color_line("sidebar_fg_color", &spec.sidebar.fg_override));
 
     css.push_str("\n/* Semantic status colors */\n");
     css.push_str(&color_line("destructive_bg_color", &sc.destructive));

--- a/crates/infra/src/theme_css/gnome45.rs
+++ b/crates/infra/src/theme_css/gnome45.rs
@@ -4,7 +4,9 @@
 //! GNOME 45 CSS adapter.
 //! Shell changes: panel reworked with .panel-button, overview restructured.
 
-use super::common::{gtk_csd_css, gtk_radius_css, gtk_tint_css, tint_shell_surfaces};
+use super::common::{
+    gtk_color_overrides_css, gtk_csd_css, gtk_radius_css, gtk_tint_css, tint_shell_surfaces,
+};
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
 use gnomex_domain::ThemeSpec;
@@ -27,9 +29,10 @@ impl ThemeCssGenerator for Gnome45CssGenerator {
 impl Gnome45CssGenerator {
     fn gtk(&self, spec: &ThemeSpec) -> String {
         format!(
-            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
+            gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
         )
     }

--- a/crates/infra/src/theme_css/gnome46.rs
+++ b/crates/infra/src/theme_css/gnome46.rs
@@ -4,7 +4,9 @@
 //! GNOME 46 CSS adapter.
 //! Shell changes: file chooser portal, minor selector refinements.
 
-use super::common::{gtk_csd_css, gtk_radius_css, gtk_tint_css, tint_shell_surfaces};
+use super::common::{
+    gtk_color_overrides_css, gtk_csd_css, gtk_radius_css, gtk_tint_css, tint_shell_surfaces,
+};
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
 use gnomex_domain::ThemeSpec;
@@ -27,9 +29,10 @@ impl ThemeCssGenerator for Gnome46CssGenerator {
 impl Gnome46CssGenerator {
     fn gtk(&self, spec: &ThemeSpec) -> String {
         format!(
-            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
+            gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
         )
     }

--- a/crates/infra/src/theme_css/gnome50.rs
+++ b/crates/infra/src/theme_css/gnome50.rs
@@ -9,7 +9,7 @@
 //! - `prefers-reduced-motion` guard on blur/animation CSS
 //! - Wayland-only (no X11 fallback paths)
 
-use super::common::{gtk_csd_css, gtk_radius_css, gtk_tint_css};
+use super::common::{gtk_color_overrides_css, gtk_csd_css, gtk_radius_css, gtk_tint_css};
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
 use gnomex_domain::ThemeSpec;
@@ -43,9 +43,10 @@ impl Gnome50CssGenerator {
         // No style-dark.css generation — Libadwaita 1.9 logs deprecation
         // warnings if it finds separate dark variant files.
         format!(
-            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
+            gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
         )
     }

--- a/crates/infra/tests/nautilus_css_fixture.rs
+++ b/crates/infra/tests/nautilus_css_fixture.rs
@@ -1,0 +1,283 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Nautilus-specific CSS fixture (GXF-023).
+//!
+//! Nautilus has a non-trivial widget tree — the left navigation sidebar,
+//! the path-bar embedded in the headerbar, and the main content view each
+//! consume a different Adwaita token. This test pins the tokens we must
+//! emit so a future refactor of the theme CSS generator cannot silently
+//! break Nautilus without a loud test failure.
+//!
+//! The left sidebar in particular relies on `sidebar_bg_color` rendering
+//! *behind* Nautilus's own semi-transparent overlay. If the token
+//! disappears or is no longer defined in both light and dark scopes, the
+//! sidebar falls back to the default Adwaita colour and our accent tint
+//! stops taking effect on the sidebar — a visually jarring regression.
+
+use gnomex_domain::{HexColor, Opacity, ShellVersion, SidebarSpec, ThemeSpec};
+use gnomex_infra::theme_css::create_css_generator;
+
+/// Tokens Nautilus's widget tree consumes from our generated GTK CSS.
+///
+/// | Nautilus widget        | Adwaita token we emit        |
+/// |------------------------|------------------------------|
+/// | `.navigation-sidebar`  | `sidebar_bg_color`           |
+/// | path-bar (in headerbar)| `headerbar_bg_color`         |
+/// | main content view      | `view_bg_color`              |
+/// | rubber-band / cards    | `card_bg_color`              |
+/// | window chrome          | `window_bg_color`            |
+const NAUTILUS_REQUIRED_TOKENS: &[&str] = &[
+    "sidebar_bg_color",
+    "headerbar_bg_color",
+    "view_bg_color",
+    "card_bg_color",
+    "window_bg_color",
+];
+
+fn all_supported_versions() -> Vec<ShellVersion> {
+    vec![
+        ShellVersion::new(45, 0),
+        ShellVersion::new(46, 0),
+        ShellVersion::new(47, 0),
+        ShellVersion::new(50, 0),
+    ]
+}
+
+#[test]
+fn nautilus_required_tokens_are_defined_in_light_and_dark() {
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator
+            .generate(&ThemeSpec::defaults())
+            .expect("CSS generation must succeed with defaults");
+
+        let (light, dark) = split_light_dark_scopes(&css.gtk_css).unwrap_or_else(|| {
+            panic!(
+                "{}: GTK CSS does not contain both light and dark @media scopes\n----\n{}",
+                generator.version_label(),
+                css.gtk_css,
+            )
+        });
+
+        for token in NAUTILUS_REQUIRED_TOKENS {
+            let needle = format!("@define-color {token}");
+            assert!(
+                light.contains(&needle),
+                "{}: light scope is missing `{needle}` — Nautilus will fall back to the default Adwaita colour.\n----\n{light}",
+                generator.version_label(),
+            );
+            assert!(
+                dark.contains(&needle),
+                "{}: dark scope is missing `{needle}` — Nautilus will fall back to the default Adwaita colour.\n----\n{dark}",
+                generator.version_label(),
+            );
+        }
+    }
+}
+
+#[test]
+fn nautilus_sidebar_uses_accent_blend_not_hardcoded_grey() {
+    // Nautilus's navigation sidebar is what users notice first when a
+    // theme "doesn't look applied". The tint formula must reference
+    // `@accent_bg_color` so the sidebar re-tints when the user switches
+    // accents, rather than being baked to a grey.
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&ThemeSpec::defaults()).unwrap();
+
+        let sidebar_line = css
+            .gtk_css
+            .lines()
+            .find(|l| l.contains("@define-color sidebar_bg_color"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "{}: no `sidebar_bg_color` definition at all\n----\n{}",
+                    generator.version_label(),
+                    css.gtk_css,
+                )
+            });
+
+        assert!(
+            sidebar_line.contains("@accent_bg_color"),
+            "{}: sidebar_bg_color does not blend with @accent_bg_color — line was `{sidebar_line}`",
+            generator.version_label(),
+        );
+        assert!(
+            sidebar_line.contains("mix("),
+            "{}: sidebar_bg_color is not a `mix()` expression — accent intensity won't scale. Line: `{sidebar_line}`",
+            generator.version_label(),
+        );
+    }
+}
+
+#[test]
+fn nautilus_content_view_contrast_separate_from_window() {
+    // Nautilus's file list sits in a `view` widget; users expect it to be
+    // subtly brighter than the window chrome behind it so folder rows are
+    // legible. The generator must emit a distinct `view_bg_color` token
+    // rather than aliasing it to `window_bg_color`.
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&ThemeSpec::defaults()).unwrap();
+        let gtk = &css.gtk_css;
+
+        let window_def = first_line_containing(gtk, "@define-color window_bg_color");
+        let view_def = first_line_containing(gtk, "@define-color view_bg_color");
+
+        let (Some(window_def), Some(view_def)) = (window_def, view_def) else {
+            panic!(
+                "{}: window_bg_color or view_bg_color missing from GTK CSS\n----\n{}",
+                generator.version_label(),
+                gtk,
+            );
+        };
+
+        assert_ne!(
+            strip_base_color(window_def),
+            strip_base_color(view_def),
+            "{}: window_bg_color and view_bg_color share the same base — Nautilus rows will be indistinguishable from chrome.",
+            generator.version_label(),
+        );
+    }
+}
+
+#[test]
+fn nautilus_card_border_consistent_with_element_radius() {
+    // Nautilus uses card-styled sidebars for "Starred", "Recent" etc.
+    // The card border-radius must follow `element_radius` so it matches
+    // buttons/entries in the toolbar — otherwise the sidebar feels
+    // visually disjoint.
+    let spec = ThemeSpec::defaults();
+    let expected_radius = format!(".card {{ border-radius: {}px; }}", spec.element_radius.as_i32());
+
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        assert!(
+            css.gtk_css.contains(&expected_radius),
+            "{}: `.card` border-radius rule does not match element_radius ({}px)\n----\n{}",
+            generator.version_label(),
+            spec.element_radius.as_i32(),
+            css.gtk_css,
+        );
+    }
+}
+
+#[test]
+fn nautilus_sidebar_opacity_wraps_mix_in_alpha_when_under_one() {
+    // Opacity == 1.0 must stay a plain mix() (readable CSS);
+    // Opacity < 1.0 must wrap the mix() in alpha(mix(...), pct).
+    // This is the core semi-transparency feature users tune to let a
+    // blurred wallpaper bleed into the Nautilus sidebar.
+    let mut spec = ThemeSpec::defaults();
+    spec.sidebar = SidebarSpec {
+        opacity: Opacity::from_fraction(0.7).unwrap(),
+        fg_override: None,
+    };
+
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        let sidebar_line = css
+            .gtk_css
+            .lines()
+            .find(|l| l.contains("@define-color sidebar_bg_color"))
+            .unwrap();
+        assert!(
+            sidebar_line.contains("alpha("),
+            "{}: sidebar_bg_color with opacity<1.0 must be alpha()-wrapped. Line: `{sidebar_line}`",
+            generator.version_label(),
+        );
+        assert!(
+            sidebar_line.contains("0.700"),
+            "{}: sidebar_bg_color alpha value missing. Line: `{sidebar_line}`",
+            generator.version_label(),
+        );
+    }
+}
+
+#[test]
+fn nautilus_sidebar_opacity_one_emits_plain_mix() {
+    // Regression guard: when the user leaves sidebar opacity at default
+    // (1.0), we must not emit an alpha() wrapper — otherwise every theme
+    // applies a one-line diff versus historical output.
+    let spec = ThemeSpec::defaults();
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        let sidebar_line = css
+            .gtk_css
+            .lines()
+            .find(|l| l.contains("@define-color sidebar_bg_color"))
+            .unwrap();
+        assert!(
+            !sidebar_line.contains("alpha("),
+            "{}: opacity=1.0 must not wrap in alpha(). Line: `{sidebar_line}`",
+            generator.version_label(),
+        );
+    }
+}
+
+#[test]
+fn nautilus_sidebar_fg_override_emits_when_set() {
+    // When the user picks a sidebar text colour, we must emit
+    // `@define-color sidebar_fg_color #rrggbb;` so Nautilus actually
+    // picks it up. When the override is None, no line is emitted and
+    // Nautilus falls back to Adwaita's scheme-dependent default.
+    let mut spec = ThemeSpec::defaults();
+    spec.sidebar = SidebarSpec {
+        opacity: Opacity::from_fraction(1.0).unwrap(),
+        fg_override: Some(HexColor::new("#ff00aa").unwrap()),
+    };
+
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        assert!(
+            css.gtk_css.contains("@define-color sidebar_fg_color #ff00aa"),
+            "{}: sidebar_fg_color override missing from GTK CSS\n----\n{}",
+            generator.version_label(),
+            css.gtk_css,
+        );
+    }
+
+    // And with the default (None), no sidebar_fg_color line is emitted.
+    let default_spec = ThemeSpec::defaults();
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&default_spec).unwrap();
+        assert!(
+            !css.gtk_css.contains("@define-color sidebar_fg_color"),
+            "{}: sidebar_fg_color emitted when fg_override is None — would clobber Adwaita defaults.",
+            generator.version_label(),
+        );
+    }
+}
+
+// -- helpers -----------------------------------------------------------
+
+fn split_light_dark_scopes(gtk_css: &str) -> Option<(String, String)> {
+    let light_start = gtk_css.find("@media (prefers-color-scheme: light)")?;
+    let dark_start = gtk_css.find("@media (prefers-color-scheme: dark)")?;
+    if dark_start <= light_start {
+        return None;
+    }
+    Some((
+        gtk_css[light_start..dark_start].to_string(),
+        gtk_css[dark_start..].to_string(),
+    ))
+}
+
+fn first_line_containing<'a>(haystack: &'a str, needle: &str) -> Option<&'a str> {
+    haystack.lines().find(|l| l.contains(needle))
+}
+
+/// Drop everything up to and including the first `mix(` open-paren so two
+/// token definitions can be compared by their base colour. Without this
+/// the alpha/blend fractions vary token-to-token and always look unequal.
+fn strip_base_color(line: &str) -> String {
+    let after_mix = line.split_once("mix(").map(|(_, r)| r).unwrap_or(line);
+    let first_arg = after_mix.split(',').next().unwrap_or("").trim();
+    first_arg.to_string()
+}

--- a/crates/ui/src/components/theme_builder.rs
+++ b/crates/ui/src/components/theme_builder.rs
@@ -10,7 +10,7 @@ use crate::services::AppServices;
 use adw::prelude::*;
 use gnomex_app::use_cases::ApplyThemeUseCase;
 use gnomex_domain::theme_capability::{self, ThemeControlId};
-use gnomex_domain::{DashSpec, HexColor, Opacity, PanelSpec, Radius, ThemeSpec, TintSpec};
+use gnomex_domain::{DashSpec, HexColor, Opacity, PanelSpec, Radius, SidebarSpec, ThemeSpec, TintSpec};
 use relm4::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -55,6 +55,9 @@ pub struct ThemeBuilderModel {
     separator_opacity: f64,
     focus_ring_width: f64,
     combo_inset: bool,
+    // Sidebar (Nautilus/Files/Disks left-nav)
+    sidebar_opacity: f64,
+    sidebar_fg_override: String,
     // Notification
     notification_radius: f64,
     notification_opacity: f64,
@@ -122,6 +125,9 @@ pub enum ThemeBuilderMsg {
     SetSeparatorOpacity(f64),
     SetFocusRingWidth(f64),
     SetComboInset(bool),
+    // Sidebar
+    SetSidebarOpacity(f64),
+    SetSidebarFgOverride(String),
     // Notifications
     SetNotificationRadius(f64),
     SetNotificationOpacity(f64),
@@ -1258,6 +1264,74 @@ impl SimpleComponent for ThemeBuilderModel {
         }
         inset_group.add(&combo_inset_switch);
 
+        // === Sidebar (Nautilus / Files / Disks left-nav) ===
+        let sidebar_group = adw::PreferencesGroup::builder()
+            .title("Sidebar")
+            .description(
+                "Controls the left navigation sidebar rendered by Nautilus, \
+                 Files, Disks, Settings, and any AdwOverlaySplitView app.",
+            )
+            .build();
+
+        let sidebar_opacity_row = build_spin_row(
+            "Sidebar Opacity",
+            "Background opacity of the left-nav sidebar (100% = opaque)",
+            0.0,
+            100.0,
+            app_settings.double("tb-sidebar-opacity") * 100.0,
+            5.0,
+        );
+        {
+            let sender = sender.clone();
+            sidebar_opacity_row.connect_value_notify(move |row| {
+                sender.input(ThemeBuilderMsg::SetSidebarOpacity(row.value() / 100.0));
+            });
+        }
+        sidebar_group.add(&sidebar_opacity_row);
+
+        let sidebar_fg_row = adw::ActionRow::builder()
+            .title("Sidebar Text Color")
+            .subtitle("Override the sidebar foreground colour. Leave default to follow the active colour scheme.")
+            .build();
+        let sidebar_fg_btn = gtk::ColorDialogButton::builder().build();
+        let sidebar_fg_dialog = gtk::ColorDialog::builder()
+            .title("Sidebar Text Color")
+            .with_alpha(false)
+            .build();
+        sidebar_fg_btn.set_dialog(&sidebar_fg_dialog);
+        let saved_sidebar_fg = app_settings.string("tb-sidebar-fg-override").to_string();
+        if let Ok(rgba) = gtk::gdk::RGBA::parse(&saved_sidebar_fg) {
+            sidebar_fg_btn.set_rgba(&rgba);
+        }
+        let sidebar_fg_reset = gtk::Button::builder()
+            .icon_name("edit-clear-symbolic")
+            .valign(gtk::Align::Center)
+            .css_classes(["flat"])
+            .tooltip_text("Reset to default (follow colour scheme)")
+            .build();
+        {
+            let sender = sender.clone();
+            sidebar_fg_btn.connect_rgba_notify(move |btn| {
+                let rgba = btn.rgba();
+                let hex = format!(
+                    "#{:02x}{:02x}{:02x}",
+                    (rgba.red() * 255.0) as u8,
+                    (rgba.green() * 255.0) as u8,
+                    (rgba.blue() * 255.0) as u8,
+                );
+                sender.input(ThemeBuilderMsg::SetSidebarFgOverride(hex));
+            });
+        }
+        {
+            let sender = sender.clone();
+            sidebar_fg_reset.connect_clicked(move |_| {
+                sender.input(ThemeBuilderMsg::SetSidebarFgOverride(String::new()));
+            });
+        }
+        sidebar_fg_row.add_suffix(&sidebar_fg_btn);
+        sidebar_fg_row.add_suffix(&sidebar_fg_reset);
+        sidebar_group.add(&sidebar_fg_row);
+
         // appended in final ordering
 
         // === Window Behavior (Mutter) ===
@@ -1402,7 +1476,7 @@ impl SimpleComponent for ThemeBuilderModel {
             &[&accent_group, &tint_group, &shared_group, &panel_group, &dash_group, &notif_group, &scheme_group],
         );
         let windows_page = build_category_page(
-            &[&radii_group, &csd_group, &inset_group, &window_group, &wm_group],
+            &[&radii_group, &csd_group, &inset_group, &sidebar_group, &window_group, &wm_group],
         );
         let typography_page = build_category_page(
             &[&font_group, &cursor_group],
@@ -1543,6 +1617,8 @@ impl SimpleComponent for ThemeBuilderModel {
             separator_opacity: app_settings.double("tb-separator-opacity"),
             focus_ring_width: app_settings.double("tb-focus-ring-width"),
             combo_inset: app_settings.boolean("tb-combo-inset"),
+            sidebar_opacity: app_settings.double("tb-sidebar-opacity"),
+            sidebar_fg_override: app_settings.string("tb-sidebar-fg-override").to_string(),
             notification_radius: app_settings.double("tb-notification-radius"),
             notification_opacity: app_settings.double("tb-notification-opacity"),
             scheduled_accent_enabled: saved_sched_enabled,
@@ -1953,6 +2029,9 @@ impl SimpleComponent for ThemeBuilderModel {
             ThemeBuilderMsg::SetSeparatorOpacity(v) => self.separator_opacity = v,
             ThemeBuilderMsg::SetFocusRingWidth(v) => self.focus_ring_width = v,
             ThemeBuilderMsg::SetComboInset(v) => self.combo_inset = v,
+            // --- Sidebar ---
+            ThemeBuilderMsg::SetSidebarOpacity(v) => self.sidebar_opacity = v,
+            ThemeBuilderMsg::SetSidebarFgOverride(v) => self.sidebar_fg_override = v,
             // --- Notifications ---
             ThemeBuilderMsg::SetNotificationRadius(v) => self.notification_radius = v,
             ThemeBuilderMsg::SetNotificationOpacity(v) => self.notification_opacity = v,
@@ -2110,6 +2189,8 @@ impl SimpleComponent for ThemeBuilderModel {
                 let _ = app.set_double("tb-separator-opacity", self.separator_opacity);
                 let _ = app.set_double("tb-focus-ring-width", self.focus_ring_width);
                 let _ = app.set_boolean("tb-combo-inset", self.combo_inset);
+                let _ = app.set_double("tb-sidebar-opacity", self.sidebar_opacity);
+                let _ = app.set_string("tb-sidebar-fg-override", &self.sidebar_fg_override);
                 let _ = app.set_double("tb-notification-radius", self.notification_radius);
                 let _ = app.set_double("tb-notification-opacity", self.notification_opacity);
 
@@ -2142,6 +2223,8 @@ impl SimpleComponent for ThemeBuilderModel {
                 self.tint_intensity = 5.0;
                 self.dash_opacity = 70.0;
                 self.overview_blur = true;
+                self.sidebar_opacity = 1.0;
+                self.sidebar_fg_override = String::new();
 
                 let _ = self.apply_uc.reset();
                 let _ = sender
@@ -2187,6 +2270,17 @@ impl ThemeBuilderModel {
                 combo_inset: self.combo_inset,
             },
             foreground: gnomex_domain::ForegroundSpec::default(),
+            sidebar: SidebarSpec {
+                opacity: Opacity::from_fraction(self.sidebar_opacity)?,
+                fg_override: {
+                    let trimmed = self.sidebar_fg_override.trim();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(HexColor::new(trimmed)?)
+                    }
+                },
+            },
             status_colors: gnomex_domain::StatusColorSpec::default(),
             notifications: gnomex_domain::NotificationSpec {
                 radius: Radius::new(self.notification_radius)?,

--- a/data/io.github.gnomex.GnomeX.gschema.xml
+++ b/data/io.github.gnomex.GnomeX.gschema.xml
@@ -124,6 +124,16 @@
       <default>true</default>
       <summary>Show combo button inset border</summary>
     </key>
+    <key name="tb-sidebar-opacity" type="d">
+      <default>1.0</default>
+      <summary>Sidebar background opacity fraction</summary>
+      <description>Controls the left-nav sidebar opacity in apps like Nautilus/Files/Disks. 1.0 = fully opaque; &lt;1.0 lets the wallpaper or compositor blur bleed through.</description>
+    </key>
+    <key name="tb-sidebar-fg-override" type="s">
+      <default>""</default>
+      <summary>Sidebar foreground override hex</summary>
+      <description>Optional #rrggbb override for sidebar text. Empty string keeps the Adwaita default.</description>
+    </key>
     <key name="tb-notification-radius" type="d">
       <default>12.0</default>
       <summary>Notification banner corner radius</summary>


### PR DESCRIPTION
## Summary

- New `SidebarSpec { opacity, fg_override }` in domain; moved the orphaned `foreground.sidebar_fg` into it so one type owns all sidebar config.
- `gtk_tint_css` now wraps `sidebar_bg_color` in `alpha(mix(...), opacity)` when the user dials opacity below 1.0; keeps the plain `mix()` otherwise for minimal diffs.
- `gtk_color_overrides_css` now runs on all GNOME version adapters (45, 46, 47, 50) — it was previously only wired on 47, so every prior foreground override silently dropped on three of the four supported versions.
- Two new `tb-sidebar-*` GSettings keys plus a "Sidebar" PreferencesGroup on the Windows page with an opacity spin row and a text-colour picker (with a clear/reset button).
- CLI reads the same keys so daemon-driven reapplies respect the user's sidebar setting.
- Integration fixture `nautilus_css_fixture.rs` pins seven invariants against every supported GNOME version.

## Why

Nautilus is the canonical "did my theme apply?" witness. Its left-nav sidebar reads `sidebar_bg_color` / `sidebar_fg_color`, and users historically reported that the sidebar "didn't look themed" — which was true: on GNOME 45/46/50 the foreground overrides never fired, and there was no user-facing opacity knob for semi-transparency.

The test fixture turns the Nautilus contract into a compile-time guard so a future CSS refactor can't silently regress any of these tokens on any version.

## Scope trade-off

I deliberately kept the sidebar `fg_override` a single colour (scheme-agnostic) rather than light/dark pair. If we need separate overrides later we can bump `SidebarSpec` without breaking wire-format — the field is plain `Option<HexColor>`.

## Test plan

- [x] `cargo test --workspace` passes.
- [x] `cargo test --test nautilus_css_fixture` — 7/7 pass.
- [x] `glib-compile-schemas --strict --dry-run data/` validates the new keys.
- [x] `cargo build -p gnomex-ui` compiles the new PreferencesGroup.
- [x] Manually verify the Sidebar group appears on the Windows tab and opacity is reflected in generated GTK CSS (requires dev-mode run).
- [x] Manually verify Nautilus picks up a 70% opacity tweak with a blurred wallpaper visible through the sidebar.

Closes #11