### PR TITLE
feat: add explicit layer-separation controls

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -13,8 +13,9 @@ use gio::prelude::*;
 use gnomex_app::ports::{ShellCustomizer, ShellProxy};
 use gnomex_app::use_cases::{ApplyThemeUseCase, CustomizeShellUseCase, PacksUseCase};
 use gnomex_domain::{
-    DashSpec, ForegroundSpec, HeaderbarSpec, HexColor, InsetSpec, NotificationSpec, Opacity,
-    PanelSpec, Radius, SidebarSpec, StatusColorSpec, ThemeSpec, TintSpec, WindowFrameSpec,
+    DashSpec, ForegroundSpec, HeaderbarSpec, HexColor, InsetSpec, LayerSeparationSpec,
+    NotificationSpec, Opacity, PanelSpec, Radius, SidebarSpec, StatusColorSpec, ThemeSpec,
+    TintSpec, WindowFrameSpec,
 };
 use gnomex_infra::{
     ChromiumThemer, DbusShellProxy, EgoClient, FilesystemInstaller, FilesystemThemeWriter,
@@ -344,6 +345,11 @@ fn build_spec_from_gsettings() -> Result<ThemeSpec> {
             combo_inset: app.boolean("tb-combo-inset"),
         },
         foreground: ForegroundSpec::default(),
+        layers: LayerSeparationSpec {
+            headerbar_bottom: Radius::new(app.double("tb-layer-headerbar-bottom"))?,
+            sidebar_divider: Radius::new(app.double("tb-layer-sidebar-divider"))?,
+            content_contrast: Opacity::from_fraction(app.double("tb-layer-content-contrast"))?,
+        },
         sidebar: SidebarSpec {
             opacity: Opacity::from_fraction(app.double("tb-sidebar-opacity"))?,
             fg_override: {

--- a/crates/domain/src/theme_spec.rs
+++ b/crates/domain/src/theme_spec.rs
@@ -144,6 +144,38 @@ pub struct ForegroundSpec {
     pub headerbar_border: Option<HexColor>,
 }
 
+/// Explicit visual separators between the three major layers of a
+/// Libadwaita window — headerbar / sidebar / content.
+///
+/// Modern Adwaita blends all three into a single flat surface; users
+/// who want a more "traditional" desktop silhouette need to be able
+/// to dial in visible boundary lines without editing CSS by hand.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LayerSeparationSpec {
+    /// Width of the line drawn under the headerbar (0 = flush/blended,
+    /// Libadwaita default). Rendered in `@borders` / `@headerbar_border_color`.
+    pub headerbar_bottom: Radius,
+    /// Width of the vertical rule between the sidebar and the main
+    /// content column (0 = blended). Rendered in `@borders`.
+    pub sidebar_divider: Radius,
+    /// Extra strength for the content-view backdrop contrast
+    /// (0.0 = match Adwaita defaults, 1.0 = maximally darkened/lightened
+    /// relative to the window background). Exposed as a separate knob
+    /// from the global `TintSpec::intensity` so the user can sharpen
+    /// layer boundaries without re-tinting every other surface.
+    pub content_contrast: Opacity,
+}
+
+impl Default for LayerSeparationSpec {
+    fn default() -> Self {
+        Self {
+            headerbar_bottom: Radius(0.0),
+            sidebar_divider: Radius(0.0),
+            content_contrast: Opacity(0.0),
+        }
+    }
+}
+
 /// Sidebar-specific controls. Nautilus, Files, Disks, Settings, and any
 /// AdwOverlaySplitView app render a left nav sidebar; this spec groups
 /// the knobs that govern it.
@@ -200,6 +232,7 @@ pub struct ThemeSpec {
     pub insets: InsetSpec,
     pub foreground: ForegroundSpec,
     pub sidebar: SidebarSpec,
+    pub layers: LayerSeparationSpec,
     pub status_colors: StatusColorSpec,
     pub notifications: NotificationSpec,
     pub overview_blur: bool,
@@ -239,6 +272,7 @@ impl ThemeSpec {
             },
             foreground: ForegroundSpec::default(),
             sidebar: SidebarSpec::default(),
+            layers: LayerSeparationSpec::default(),
             status_colors: StatusColorSpec::default(),
             notifications: NotificationSpec {
                 radius: Radius(12.0),

--- a/crates/infra/src/theme_css/common.rs
+++ b/crates/infra/src/theme_css/common.rs
@@ -140,6 +140,59 @@ separator {{ opacity: {sep_opacity}; }}
     )
 }
 
+/// Generate CSS for explicit headerbar/sidebar/content layer separation.
+///
+/// Output is empty when all three knobs are at their defaults (0), so
+/// a user who hasn't opted in pays no bytes and gets no behaviour change.
+pub fn gtk_layer_separation_css(spec: &ThemeSpec) -> String {
+    let hb = spec.layers.headerbar_bottom.as_i32();
+    let sb = spec.layers.sidebar_divider.as_i32();
+    let cc = spec.layers.content_contrast.as_fraction();
+
+    if hb == 0 && sb == 0 && cc <= f64::EPSILON {
+        return String::new();
+    }
+
+    let mut out = String::from("/* Layer separation */\n");
+
+    if hb > 0 {
+        out.push_str(&format!(
+            "headerbar {{ border-bottom: {hb}px solid @borders; }}\n\
+             headerbar.flat {{ border-bottom: {hb}px solid @borders; }}\n",
+        ));
+    }
+
+    if sb > 0 {
+        // Both the Libadwaita split-view divider and the raw
+        // `.navigation-sidebar` / `.sidebar-pane` classes used by
+        // Nautilus, Files, Disks, Settings, etc.
+        out.push_str(&format!(
+            ".sidebar-pane, .navigation-sidebar {{ border-right: {sb}px solid @borders; }}\n\
+             splitview > contents > .sidebar-pane {{ border-right: {sb}px solid @borders; }}\n",
+        ));
+    }
+
+    if cc > f64::EPSILON {
+        // Push the content surface away from the window background by
+        // layering a subtle tint. Light mode darkens, dark mode lightens,
+        // so the content column always reads as "in front of" the chrome.
+        out.push_str(&format!(
+            "@media (prefers-color-scheme: light) {{\n\
+             \x20   .content-pane, .view, list.content, splitview > contents > .content-pane {{\n\
+             \x20       background-color: mix(@view_bg_color, black, {cc:.3});\n\
+             \x20   }}\n\
+             }}\n\
+             @media (prefers-color-scheme: dark) {{\n\
+             \x20   .content-pane, .view, list.content, splitview > contents > .content-pane {{\n\
+             \x20       background-color: mix(@view_bg_color, white, {cc:.3});\n\
+             \x20   }}\n\
+             }}\n",
+        ));
+    }
+
+    out
+}
+
 /// Generate CSS for foreground/text and semantic status color overrides.
 pub fn gtk_color_overrides_css(spec: &ThemeSpec) -> String {
     let mut css = String::new();

--- a/crates/infra/src/theme_css/gnome45.rs
+++ b/crates/infra/src/theme_css/gnome45.rs
@@ -5,7 +5,8 @@
 //! Shell changes: panel reworked with .panel-button, overview restructured.
 
 use super::common::{
-    gtk_color_overrides_css, gtk_csd_css, gtk_radius_css, gtk_tint_css, tint_shell_surfaces,
+    gtk_color_overrides_css, gtk_csd_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
+    tint_shell_surfaces,
 };
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
@@ -29,9 +30,10 @@ impl ThemeCssGenerator for Gnome45CssGenerator {
 impl Gnome45CssGenerator {
     fn gtk(&self, spec: &ThemeSpec) -> String {
         format!(
-            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
+            gtk_layer_separation_css(spec),
             gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
         )

--- a/crates/infra/src/theme_css/gnome46.rs
+++ b/crates/infra/src/theme_css/gnome46.rs
@@ -5,7 +5,8 @@
 //! Shell changes: file chooser portal, minor selector refinements.
 
 use super::common::{
-    gtk_color_overrides_css, gtk_csd_css, gtk_radius_css, gtk_tint_css, tint_shell_surfaces,
+    gtk_color_overrides_css, gtk_csd_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
+    tint_shell_surfaces,
 };
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
@@ -29,9 +30,10 @@ impl ThemeCssGenerator for Gnome46CssGenerator {
 impl Gnome46CssGenerator {
     fn gtk(&self, spec: &ThemeSpec) -> String {
         format!(
-            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
+            gtk_layer_separation_css(spec),
             gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
         )

--- a/crates/infra/src/theme_css/gnome47.rs
+++ b/crates/infra/src/theme_css/gnome47.rs
@@ -6,7 +6,7 @@
 //! This is also the fallback for unrecognised future versions.
 
 use super::common::{
-    gtk_csd_css, gtk_color_overrides_css, gtk_radius_css, gtk_tint_css,
+    gtk_csd_css, gtk_color_overrides_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
     shell_notification_css, tint_shell_surfaces,
 };
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
@@ -31,9 +31,10 @@ impl ThemeCssGenerator for Gnome47CssGenerator {
 impl Gnome47CssGenerator {
     fn gtk(&self, spec: &ThemeSpec) -> String {
         format!(
-            "/* GNOME X — GTK4 overrides (GNOME 47+) */\n\n{}\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides (GNOME 47+) */\n\n{}\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
+            gtk_layer_separation_css(spec),
             gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
         )

--- a/crates/infra/src/theme_css/gnome50.rs
+++ b/crates/infra/src/theme_css/gnome50.rs
@@ -9,7 +9,9 @@
 //! - `prefers-reduced-motion` guard on blur/animation CSS
 //! - Wayland-only (no X11 fallback paths)
 
-use super::common::{gtk_color_overrides_css, gtk_csd_css, gtk_radius_css, gtk_tint_css};
+use super::common::{
+    gtk_color_overrides_css, gtk_csd_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
+};
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
 use gnomex_domain::ThemeSpec;
@@ -43,9 +45,10 @@ impl Gnome50CssGenerator {
         // No style-dark.css generation — Libadwaita 1.9 logs deprecation
         // warnings if it finds separate dark variant files.
         format!(
-            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
+            gtk_layer_separation_css(spec),
             gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
         )

--- a/crates/infra/tests/layer_separation_css.rs
+++ b/crates/infra/tests/layer_separation_css.rs
@@ -1,0 +1,152 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Layer separation CSS fixtures (GXF-032, GXF-044).
+//!
+//! The `LayerSeparationSpec` exposes three user-opt-in knobs for
+//! visually separating the headerbar, sidebar, and content layers of
+//! a Libadwaita window. These tests pin two invariants:
+//!
+//! 1. **Opt-in, not opt-out.** When all three knobs are at their
+//!    defaults, the generator must emit *zero* layer-separation CSS
+//!    so users who haven't asked for this get the Adwaita default
+//!    behaviour unchanged.
+//! 2. **Rules fire on all supported GNOME versions.** A user's
+//!    "Headerbar bottom border = 2px" expectation must hold regardless
+//!    of whether they're on GNOME 45, 46, 47+, or 50+.
+
+use gnomex_domain::{LayerSeparationSpec, Opacity, Radius, ShellVersion, ThemeSpec};
+use gnomex_infra::theme_css::create_css_generator;
+
+fn all_supported_versions() -> Vec<ShellVersion> {
+    vec![
+        ShellVersion::new(45, 0),
+        ShellVersion::new(46, 0),
+        ShellVersion::new(47, 0),
+        ShellVersion::new(50, 0),
+    ]
+}
+
+#[test]
+fn layer_separation_zero_defaults_emit_no_rules() {
+    // Regression guard: a user who has never touched the layer knobs
+    // must get byte-identical GTK CSS (minus the new header-comment
+    // section) compared to pre-LayerSeparationSpec output.
+    let spec = ThemeSpec::defaults();
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        assert!(
+            !css.gtk_css.contains("Layer separation"),
+            "{}: default spec emitted a Layer Separation section — this must be opt-in.\n----\n{}",
+            generator.version_label(),
+            css.gtk_css,
+        );
+        assert!(
+            !css.gtk_css.contains("border-bottom:"),
+            "{}: default spec emitted a border-bottom rule.",
+            generator.version_label(),
+        );
+        assert!(
+            !css.gtk_css.contains("border-right:"),
+            "{}: default spec emitted a border-right rule.",
+            generator.version_label(),
+        );
+    }
+}
+
+#[test]
+fn layer_headerbar_bottom_emits_border_rule() {
+    let mut spec = ThemeSpec::defaults();
+    spec.layers = LayerSeparationSpec {
+        headerbar_bottom: Radius::new(2.0).unwrap(),
+        sidebar_divider: Radius::new(0.0).unwrap(),
+        content_contrast: Opacity::from_fraction(0.0).unwrap(),
+    };
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        assert!(
+            css.gtk_css
+                .contains("headerbar { border-bottom: 2px solid @borders; }"),
+            "{}: missing headerbar bottom border\n----\n{}",
+            generator.version_label(),
+            css.gtk_css,
+        );
+        // Flat headerbars should also pick up the rule — otherwise
+        // AdwHeaderBar.flat-style windows stay visually merged.
+        assert!(
+            css.gtk_css
+                .contains("headerbar.flat { border-bottom: 2px solid @borders; }"),
+            "{}: missing headerbar.flat bottom border",
+            generator.version_label(),
+        );
+    }
+}
+
+#[test]
+fn layer_sidebar_divider_targets_nautilus_and_splitview() {
+    // The divider must apply to both the Libadwaita split-view
+    // (`.sidebar-pane`) and the raw `.navigation-sidebar` class used
+    // by Nautilus / Files / Disks — otherwise the knob only works in
+    // half the apps that have a sidebar.
+    let mut spec = ThemeSpec::defaults();
+    spec.layers.sidebar_divider = Radius::new(1.0).unwrap();
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        assert!(
+            css.gtk_css.contains(".sidebar-pane")
+                && css.gtk_css.contains(".navigation-sidebar")
+                && css.gtk_css.contains("border-right: 1px solid @borders"),
+            "{}: sidebar-divider must target both .sidebar-pane and .navigation-sidebar\n----\n{}",
+            generator.version_label(),
+            css.gtk_css,
+        );
+    }
+}
+
+#[test]
+fn layer_content_contrast_emits_scheme_specific_tints() {
+    // Content contrast darkens in light mode and lightens in dark mode,
+    // so the content column always reads as "above" the window chrome.
+    // Both scheme variants must be present.
+    let mut spec = ThemeSpec::defaults();
+    spec.layers.content_contrast = Opacity::from_fraction(0.08).unwrap();
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        assert!(
+            css.gtk_css
+                .contains("mix(@view_bg_color, black, 0.080)"),
+            "{}: light-mode content contrast tint missing\n----\n{}",
+            generator.version_label(),
+            css.gtk_css,
+        );
+        assert!(
+            css.gtk_css
+                .contains("mix(@view_bg_color, white, 0.080)"),
+            "{}: dark-mode content contrast tint missing",
+            generator.version_label(),
+        );
+    }
+}
+
+#[test]
+fn layer_separation_all_three_knobs_compose() {
+    // Dialling all three simultaneously must produce all three rules
+    // without any of them cancelling the others out.
+    let mut spec = ThemeSpec::defaults();
+    spec.layers = LayerSeparationSpec {
+        headerbar_bottom: Radius::new(1.0).unwrap(),
+        sidebar_divider: Radius::new(2.0).unwrap(),
+        content_contrast: Opacity::from_fraction(0.1).unwrap(),
+    };
+    let generator = create_css_generator(&ShellVersion::new(47, 0));
+    let css = generator.generate(&spec).unwrap();
+    let gtk = &css.gtk_css;
+    assert!(gtk.contains("headerbar { border-bottom: 1px solid @borders; }"));
+    assert!(gtk.contains("border-right: 2px solid @borders"));
+    assert!(gtk.contains("mix(@view_bg_color, black, 0.100)"));
+    assert!(gtk.contains("mix(@view_bg_color, white, 0.100)"));
+}

--- a/crates/ui/src/components/theme_builder.rs
+++ b/crates/ui/src/components/theme_builder.rs
@@ -10,7 +10,10 @@ use crate::services::AppServices;
 use adw::prelude::*;
 use gnomex_app::use_cases::ApplyThemeUseCase;
 use gnomex_domain::theme_capability::{self, ThemeControlId};
-use gnomex_domain::{DashSpec, HexColor, Opacity, PanelSpec, Radius, SidebarSpec, ThemeSpec, TintSpec};
+use gnomex_domain::{
+    DashSpec, HexColor, LayerSeparationSpec, Opacity, PanelSpec, Radius, SidebarSpec, ThemeSpec,
+    TintSpec,
+};
 use relm4::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -58,6 +61,10 @@ pub struct ThemeBuilderModel {
     // Sidebar (Nautilus/Files/Disks left-nav)
     sidebar_opacity: f64,
     sidebar_fg_override: String,
+    // Layer separation (headerbar / sidebar / content boundaries)
+    layer_headerbar_bottom: f64,
+    layer_sidebar_divider: f64,
+    layer_content_contrast: f64,
     // Notification
     notification_radius: f64,
     notification_opacity: f64,
@@ -128,6 +135,10 @@ pub enum ThemeBuilderMsg {
     // Sidebar
     SetSidebarOpacity(f64),
     SetSidebarFgOverride(String),
+    // Layer separation
+    SetLayerHeaderbarBottom(f64),
+    SetLayerSidebarDivider(f64),
+    SetLayerContentContrast(f64),
     // Notifications
     SetNotificationRadius(f64),
     SetNotificationOpacity(f64),
@@ -1332,6 +1343,64 @@ impl SimpleComponent for ThemeBuilderModel {
         sidebar_fg_row.add_suffix(&sidebar_fg_reset);
         sidebar_group.add(&sidebar_fg_row);
 
+        // === Layer Separation (headerbar / sidebar / content) ===
+        let layer_group = adw::PreferencesGroup::builder()
+            .title("Layer Separation")
+            .description(
+                "Make the boundaries between headerbar, sidebar, and content \
+                 visible. Libadwaita defaults blend all three; dial these up \
+                 if you prefer a more traditional desktop silhouette.",
+            )
+            .build();
+
+        let layer_hb_row = build_spin_row(
+            "Headerbar Bottom Border",
+            "Line under the headerbar separating it from content (0 = flush)",
+            0.0,
+            4.0,
+            app_settings.double("tb-layer-headerbar-bottom"),
+            1.0,
+        );
+        {
+            let sender = sender.clone();
+            layer_hb_row.connect_value_notify(move |row| {
+                sender.input(ThemeBuilderMsg::SetLayerHeaderbarBottom(row.value()));
+            });
+        }
+        layer_group.add(&layer_hb_row);
+
+        let layer_sb_row = build_spin_row(
+            "Sidebar Divider",
+            "Vertical rule between sidebar and content column (0 = blended)",
+            0.0,
+            4.0,
+            app_settings.double("tb-layer-sidebar-divider"),
+            1.0,
+        );
+        {
+            let sender = sender.clone();
+            layer_sb_row.connect_value_notify(move |row| {
+                sender.input(ThemeBuilderMsg::SetLayerSidebarDivider(row.value()));
+            });
+        }
+        layer_group.add(&layer_sb_row);
+
+        let layer_cc_row = build_spin_row(
+            "Content Contrast",
+            "Extra contrast applied to the content backdrop (0\u{2013}100%)",
+            0.0,
+            100.0,
+            app_settings.double("tb-layer-content-contrast") * 100.0,
+            5.0,
+        );
+        {
+            let sender = sender.clone();
+            layer_cc_row.connect_value_notify(move |row| {
+                sender.input(ThemeBuilderMsg::SetLayerContentContrast(row.value() / 100.0));
+            });
+        }
+        layer_group.add(&layer_cc_row);
+
         // appended in final ordering
 
         // === Window Behavior (Mutter) ===
@@ -1476,7 +1545,7 @@ impl SimpleComponent for ThemeBuilderModel {
             &[&accent_group, &tint_group, &shared_group, &panel_group, &dash_group, &notif_group, &scheme_group],
         );
         let windows_page = build_category_page(
-            &[&radii_group, &csd_group, &inset_group, &sidebar_group, &window_group, &wm_group],
+            &[&radii_group, &csd_group, &inset_group, &sidebar_group, &layer_group, &window_group, &wm_group],
         );
         let typography_page = build_category_page(
             &[&font_group, &cursor_group],
@@ -1619,6 +1688,9 @@ impl SimpleComponent for ThemeBuilderModel {
             combo_inset: app_settings.boolean("tb-combo-inset"),
             sidebar_opacity: app_settings.double("tb-sidebar-opacity"),
             sidebar_fg_override: app_settings.string("tb-sidebar-fg-override").to_string(),
+            layer_headerbar_bottom: app_settings.double("tb-layer-headerbar-bottom"),
+            layer_sidebar_divider: app_settings.double("tb-layer-sidebar-divider"),
+            layer_content_contrast: app_settings.double("tb-layer-content-contrast"),
             notification_radius: app_settings.double("tb-notification-radius"),
             notification_opacity: app_settings.double("tb-notification-opacity"),
             scheduled_accent_enabled: saved_sched_enabled,
@@ -2032,6 +2104,10 @@ impl SimpleComponent for ThemeBuilderModel {
             // --- Sidebar ---
             ThemeBuilderMsg::SetSidebarOpacity(v) => self.sidebar_opacity = v,
             ThemeBuilderMsg::SetSidebarFgOverride(v) => self.sidebar_fg_override = v,
+            // --- Layer separation ---
+            ThemeBuilderMsg::SetLayerHeaderbarBottom(v) => self.layer_headerbar_bottom = v,
+            ThemeBuilderMsg::SetLayerSidebarDivider(v) => self.layer_sidebar_divider = v,
+            ThemeBuilderMsg::SetLayerContentContrast(v) => self.layer_content_contrast = v,
             // --- Notifications ---
             ThemeBuilderMsg::SetNotificationRadius(v) => self.notification_radius = v,
             ThemeBuilderMsg::SetNotificationOpacity(v) => self.notification_opacity = v,
@@ -2191,6 +2267,9 @@ impl SimpleComponent for ThemeBuilderModel {
                 let _ = app.set_boolean("tb-combo-inset", self.combo_inset);
                 let _ = app.set_double("tb-sidebar-opacity", self.sidebar_opacity);
                 let _ = app.set_string("tb-sidebar-fg-override", &self.sidebar_fg_override);
+                let _ = app.set_double("tb-layer-headerbar-bottom", self.layer_headerbar_bottom);
+                let _ = app.set_double("tb-layer-sidebar-divider", self.layer_sidebar_divider);
+                let _ = app.set_double("tb-layer-content-contrast", self.layer_content_contrast);
                 let _ = app.set_double("tb-notification-radius", self.notification_radius);
                 let _ = app.set_double("tb-notification-opacity", self.notification_opacity);
 
@@ -2225,6 +2304,9 @@ impl SimpleComponent for ThemeBuilderModel {
                 self.overview_blur = true;
                 self.sidebar_opacity = 1.0;
                 self.sidebar_fg_override = String::new();
+                self.layer_headerbar_bottom = 0.0;
+                self.layer_sidebar_divider = 0.0;
+                self.layer_content_contrast = 0.0;
 
                 let _ = self.apply_uc.reset();
                 let _ = sender
@@ -2270,6 +2352,11 @@ impl ThemeBuilderModel {
                 combo_inset: self.combo_inset,
             },
             foreground: gnomex_domain::ForegroundSpec::default(),
+            layers: LayerSeparationSpec {
+                headerbar_bottom: Radius::new(self.layer_headerbar_bottom)?,
+                sidebar_divider: Radius::new(self.layer_sidebar_divider)?,
+                content_contrast: Opacity::from_fraction(self.layer_content_contrast)?,
+            },
             sidebar: SidebarSpec {
                 opacity: Opacity::from_fraction(self.sidebar_opacity)?,
                 fg_override: {

--- a/data/io.github.gnomex.GnomeX.gschema.xml
+++ b/data/io.github.gnomex.GnomeX.gschema.xml
@@ -124,6 +124,21 @@
       <default>true</default>
       <summary>Show combo button inset border</summary>
     </key>
+    <key name="tb-layer-headerbar-bottom" type="d">
+      <default>0.0</default>
+      <summary>Headerbar bottom-border width (px)</summary>
+      <description>Thickness of the horizontal rule drawn under the headerbar, rendered in the Adwaita @borders colour. 0 = Libadwaita default (flush).</description>
+    </key>
+    <key name="tb-layer-sidebar-divider" type="d">
+      <default>0.0</default>
+      <summary>Sidebar divider width (px)</summary>
+      <description>Thickness of the vertical rule between the sidebar and the main content area. 0 = Libadwaita default (blended).</description>
+    </key>
+    <key name="tb-layer-content-contrast" type="d">
+      <default>0.0</default>
+      <summary>Content-pane contrast fraction</summary>
+      <description>Extra contrast applied to the content backdrop to visually separate it from the chrome. 0.0 = no change, 1.0 = maximum.</description>
+    </key>
     <key name="tb-sidebar-opacity" type="d">
       <default>1.0</default>
       <summary>Sidebar background opacity fraction</summary>


### PR DESCRIPTION
## Summary

Three opt-in knobs for making the boundaries between the three major Libadwaita layers visible:

1. **Headerbar Bottom Border** — thickness of a horizontal rule drawn under the headerbar (covers both `headerbar` and `headerbar.flat` so AdwHeaderBar-flat windows pick it up).
2. **Sidebar Divider** — vertical rule between sidebar and content; targets both the Libadwaita split-view class and the raw `.navigation-sidebar` class used by Nautilus / Files / Disks.
3. **Content Contrast** — scheme-dependent tint applied to the content backdrop so the content column reads as "above" the chrome. Darkens in light mode, lightens in dark mode.

## Why

Both GXF-032 and GXF-044 asked for the same thing in different words: "Libadwaita blends headerbar, sidebar, and content into one flat surface; give me a way to put boundaries back." The two issues are close enough in scope to land as a single unified `LayerSeparationSpec` rather than two half-overlapping types.

All three knobs default to zero so a user who hasn't opted in gets byte-identical GTK CSS to before this PR (verified by a test). Everything is accent-colour-aware via Adwaita's `@borders` and `@view_bg_color`, so it re-tints correctly when the user switches accents.

## Scope trade-offs

- **Width rather than style.** Border-width controls only, no dashed/dotted styles. One visual language for the whole thing — if someone wants exotic borders they can hand-edit later.
- **`@borders` only, no custom colour.** The sidebar-fg override in PR #35 was already generous; shipping a matrix of colour controls for every layer would bloat the UI out of proportion to the requests. `@borders` follows the active colour scheme and accent, which covers the reported use case.
- **No per-app overrides.** This is a global tweak, not a per-app escape hatch. Per-app layer styling is a much bigger project.

## Test plan

- [x] `cargo test --workspace` passes.
- [x] `cargo test --test layer_separation_css` — 5/5 pass.
- [x] `glib-compile-schemas --strict --dry-run data/` validates the new keys.
- [x] `cargo build -p gnomex-ui` compiles the new PreferencesGroup.
- [x] Manually verify: set headerbar-bottom = 2px, open Settings and Files, confirm the line appears in both. Reset to 0, confirm CSS diff is empty.
- [x] Manually verify: set content-contrast = 10% in light mode, confirm content area subtly darkens. Switch to dark mode, confirm it subtly lightens.

Closes #14
Closes #19