### PR TITLE
feat: add Widget Style controls (input inset, button raise, gradient)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -15,7 +15,7 @@ use gnomex_app::use_cases::{ApplyThemeUseCase, CustomizeShellUseCase, PacksUseCa
 use gnomex_domain::{
     DashSpec, ForegroundSpec, HeaderbarSpec, HexColor, InsetSpec, LayerSeparationSpec,
     NotificationSpec, Opacity, PanelSpec, Radius, SidebarSpec, StatusColorSpec, ThemeSpec,
-    TintSpec, WindowFrameSpec,
+    TintSpec, WidgetStyleSpec, WindowFrameSpec,
 };
 use gnomex_infra::{
     ChromiumThemer, DbusShellProxy, EgoClient, FilesystemInstaller, FilesystemThemeWriter,
@@ -349,6 +349,11 @@ fn build_spec_from_gsettings() -> Result<ThemeSpec> {
             headerbar_bottom: Radius::new(app.double("tb-layer-headerbar-bottom"))?,
             sidebar_divider: Radius::new(app.double("tb-layer-sidebar-divider"))?,
             content_contrast: Opacity::from_fraction(app.double("tb-layer-content-contrast"))?,
+        },
+        widget_style: WidgetStyleSpec {
+            input_inset: Opacity::from_fraction(app.double("tb-widget-input-inset"))?,
+            button_raise: Opacity::from_fraction(app.double("tb-widget-button-raise"))?,
+            headerbar_gradient: Opacity::from_fraction(app.double("tb-widget-headerbar-gradient"))?,
         },
         sidebar: SidebarSpec {
             opacity: Opacity::from_fraction(app.double("tb-sidebar-opacity"))?,

--- a/crates/domain/src/theme_spec.rs
+++ b/crates/domain/src/theme_spec.rs
@@ -144,6 +144,37 @@ pub struct ForegroundSpec {
     pub headerbar_border: Option<HexColor>,
 }
 
+/// "Restore traditional widget styling" opt-ins. Modern Adwaita draws
+/// flat, chromeless inputs, buttons, and headerbars. Users coming from
+/// GNOME 3.x / pre-Libadwaita desktops often want some of that chrome
+/// back. Each knob is a 0.0–1.0 intensity; 0.0 emits no CSS (byte-
+/// identical to current output) and higher values scale the effect.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WidgetStyleSpec {
+    /// Inset strength for input fields. Above 0, `entry` widgets gain
+    /// a visible background and border distinct from the surrounding
+    /// surface. At 1.0 inputs read as clearly depressed.
+    pub input_inset: Opacity,
+    /// Raised-button affordance. Above 0, `button` widgets gain a
+    /// subtle border + shadow so they read as pressable rather than
+    /// flat text. At 1.0 buttons look clearly 3-D.
+    pub button_raise: Opacity,
+    /// Headerbar / toolbar gradient intensity. Above 0, a top→bottom
+    /// linear gradient is applied. Conflicts with Adwaita's flat
+    /// philosophy — use sparingly.
+    pub headerbar_gradient: Opacity,
+}
+
+impl Default for WidgetStyleSpec {
+    fn default() -> Self {
+        Self {
+            input_inset: Opacity(0.0),
+            button_raise: Opacity(0.0),
+            headerbar_gradient: Opacity(0.0),
+        }
+    }
+}
+
 /// Explicit visual separators between the three major layers of a
 /// Libadwaita window — headerbar / sidebar / content.
 ///
@@ -233,6 +264,7 @@ pub struct ThemeSpec {
     pub foreground: ForegroundSpec,
     pub sidebar: SidebarSpec,
     pub layers: LayerSeparationSpec,
+    pub widget_style: WidgetStyleSpec,
     pub status_colors: StatusColorSpec,
     pub notifications: NotificationSpec,
     pub overview_blur: bool,
@@ -273,6 +305,7 @@ impl ThemeSpec {
             foreground: ForegroundSpec::default(),
             sidebar: SidebarSpec::default(),
             layers: LayerSeparationSpec::default(),
+            widget_style: WidgetStyleSpec::default(),
             status_colors: StatusColorSpec::default(),
             notifications: NotificationSpec {
                 radius: Radius(12.0),

--- a/crates/infra/src/theme_css/common.rs
+++ b/crates/infra/src/theme_css/common.rs
@@ -140,6 +140,85 @@ separator {{ opacity: {sep_opacity}; }}
     )
 }
 
+/// Generate CSS for "restore traditional widget styling" opt-ins
+/// (inputs, buttons, headerbar gradients). All knobs at 0.0 yields an
+/// empty string so default-spec output stays byte-compatible.
+pub fn gtk_widget_style_css(spec: &ThemeSpec) -> String {
+    let input = spec.widget_style.input_inset.as_fraction();
+    let button = spec.widget_style.button_raise.as_fraction();
+    let gradient = spec.widget_style.headerbar_gradient.as_fraction();
+
+    if input <= f64::EPSILON && button <= f64::EPSILON && gradient <= f64::EPSILON {
+        return String::new();
+    }
+
+    let mut out = String::from("/* Widget style */\n");
+
+    if input > f64::EPSILON {
+        // The inset darkens in light mode (gives the "sunken white
+        // field" look) and lightens in dark mode so the field still
+        // reads as a distinct surface against a dark window.
+        let border_alpha = 0.08 + 0.22 * input;
+        let bg_shift = 0.04 + 0.12 * input;
+        out.push_str(&format!(
+            "@media (prefers-color-scheme: light) {{\n\
+             \x20   entry, entry.flat, spinbutton, spinbutton.flat {{\n\
+             \x20       background-color: mix(@view_bg_color, black, {bg_shift:.3});\n\
+             \x20       border: 1px solid alpha(black, {border_alpha:.3});\n\
+             \x20       box-shadow: inset 0 1px 0 alpha(black, {inset_shadow:.3});\n\
+             \x20   }}\n\
+             }}\n\
+             @media (prefers-color-scheme: dark) {{\n\
+             \x20   entry, entry.flat, spinbutton, spinbutton.flat {{\n\
+             \x20       background-color: mix(@view_bg_color, white, {bg_shift:.3});\n\
+             \x20       border: 1px solid alpha(white, {border_alpha:.3});\n\
+             \x20       box-shadow: inset 0 1px 0 alpha(black, {inset_shadow:.3});\n\
+             \x20   }}\n\
+             }}\n",
+            inset_shadow = 0.10 * input,
+        ));
+    }
+
+    if button > f64::EPSILON {
+        let border_alpha = 0.10 + 0.25 * button;
+        let shadow_alpha = 0.08 + 0.15 * button;
+        out.push_str(&format!(
+            "button:not(.flat):not(.suggested-action):not(.destructive-action) {{\n\
+             \x20   border: 1px solid alpha(currentColor, {border_alpha:.3});\n\
+             \x20   box-shadow: 0 1px 0 alpha(black, {shadow_alpha:.3});\n\
+             }}\n\
+             button:not(.flat):not(.suggested-action):not(.destructive-action):active {{\n\
+             \x20   box-shadow: inset 0 1px 0 alpha(black, {shadow_alpha:.3});\n\
+             }}\n",
+        ));
+    }
+
+    if gradient > f64::EPSILON {
+        // Subtle vertical gradient on headerbars and toolbars. The
+        // delta is capped so even gradient=1.0 stays visually tasteful
+        // rather than Win98-chrome.
+        let delta = 0.03 + 0.06 * gradient;
+        out.push_str(&format!(
+            "@media (prefers-color-scheme: light) {{\n\
+             \x20   headerbar, .toolbar {{\n\
+             \x20       background-image: linear-gradient(to bottom,\n\
+             \x20           @headerbar_bg_color,\n\
+             \x20           mix(@headerbar_bg_color, black, {delta:.3}));\n\
+             \x20   }}\n\
+             }}\n\
+             @media (prefers-color-scheme: dark) {{\n\
+             \x20   headerbar, .toolbar {{\n\
+             \x20       background-image: linear-gradient(to bottom,\n\
+             \x20           mix(@headerbar_bg_color, white, {delta:.3}),\n\
+             \x20           @headerbar_bg_color);\n\
+             \x20   }}\n\
+             }}\n",
+        ));
+    }
+
+    out
+}
+
 /// Generate CSS for explicit headerbar/sidebar/content layer separation.
 ///
 /// Output is empty when all three knobs are at their defaults (0), so

--- a/crates/infra/src/theme_css/gnome45.rs
+++ b/crates/infra/src/theme_css/gnome45.rs
@@ -6,7 +6,7 @@
 
 use super::common::{
     gtk_color_overrides_css, gtk_csd_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
-    tint_shell_surfaces,
+    gtk_widget_style_css, tint_shell_surfaces,
 };
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
@@ -30,10 +30,11 @@ impl ThemeCssGenerator for Gnome45CssGenerator {
 impl Gnome45CssGenerator {
     fn gtk(&self, spec: &ThemeSpec) -> String {
         format!(
-            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
             gtk_layer_separation_css(spec),
+            gtk_widget_style_css(spec),
             gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
         )

--- a/crates/infra/src/theme_css/gnome46.rs
+++ b/crates/infra/src/theme_css/gnome46.rs
@@ -6,7 +6,7 @@
 
 use super::common::{
     gtk_color_overrides_css, gtk_csd_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
-    tint_shell_surfaces,
+    gtk_widget_style_css, tint_shell_surfaces,
 };
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
@@ -30,10 +30,11 @@ impl ThemeCssGenerator for Gnome46CssGenerator {
 impl Gnome46CssGenerator {
     fn gtk(&self, spec: &ThemeSpec) -> String {
         format!(
-            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
             gtk_layer_separation_css(spec),
+            gtk_widget_style_css(spec),
             gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
         )

--- a/crates/infra/src/theme_css/gnome47.rs
+++ b/crates/infra/src/theme_css/gnome47.rs
@@ -7,7 +7,7 @@
 
 use super::common::{
     gtk_csd_css, gtk_color_overrides_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
-    shell_notification_css, tint_shell_surfaces,
+    gtk_widget_style_css, shell_notification_css, tint_shell_surfaces,
 };
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
@@ -31,10 +31,11 @@ impl ThemeCssGenerator for Gnome47CssGenerator {
 impl Gnome47CssGenerator {
     fn gtk(&self, spec: &ThemeSpec) -> String {
         format!(
-            "/* GNOME X — GTK4 overrides (GNOME 47+) */\n\n{}\n{}\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides (GNOME 47+) */\n\n{}\n{}\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
             gtk_layer_separation_css(spec),
+            gtk_widget_style_css(spec),
             gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
         )

--- a/crates/infra/src/theme_css/gnome50.rs
+++ b/crates/infra/src/theme_css/gnome50.rs
@@ -11,6 +11,7 @@
 
 use super::common::{
     gtk_color_overrides_css, gtk_csd_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
+    gtk_widget_style_css,
 };
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
@@ -45,10 +46,11 @@ impl Gnome50CssGenerator {
         // No style-dark.css generation — Libadwaita 1.9 logs deprecation
         // warnings if it finds separate dark variant files.
         format!(
-            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
             gtk_layer_separation_css(spec),
+            gtk_widget_style_css(spec),
             gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
         )

--- a/crates/infra/tests/widget_style_css.rs
+++ b/crates/infra/tests/widget_style_css.rs
@@ -1,0 +1,137 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Widget-style CSS fixtures (GXF-041, GXF-042, GXF-043).
+//!
+//! `WidgetStyleSpec` exposes three opt-in knobs for restoring
+//! traditional widget affordances against the flat Adwaita baseline.
+//! These tests pin three invariants:
+//!
+//! 1. **Opt-in.** All knobs at 0 yields zero widget-style CSS.
+//! 2. **Version-universal.** Rules must fire on every supported
+//!    GNOME version — the complaint "buttons look flat" doesn't
+//!    care which version we detected.
+//! 3. **Scope-safe.** The button rule must skip `.flat`,
+//!    `.suggested-action`, and `.destructive-action` so we don't
+//!    re-frame widgets Libadwaita deliberately draws flat (flat
+//!    toolbar buttons, pill-shaped suggested-action primaries).
+
+use gnomex_domain::{Opacity, ShellVersion, ThemeSpec, WidgetStyleSpec};
+use gnomex_infra::theme_css::create_css_generator;
+
+fn all_supported_versions() -> Vec<ShellVersion> {
+    vec![
+        ShellVersion::new(45, 0),
+        ShellVersion::new(46, 0),
+        ShellVersion::new(47, 0),
+        ShellVersion::new(50, 0),
+    ]
+}
+
+#[test]
+fn widget_style_zero_defaults_emit_no_rules() {
+    let spec = ThemeSpec::defaults();
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        assert!(
+            !css.gtk_css.contains("Widget style"),
+            "{}: default spec emitted a Widget Style section — must be opt-in.\n----\n{}",
+            generator.version_label(),
+            css.gtk_css,
+        );
+        assert!(!css.gtk_css.contains("linear-gradient("));
+    }
+}
+
+#[test]
+fn widget_input_inset_emits_scheme_specific_entries() {
+    let mut spec = ThemeSpec::defaults();
+    spec.widget_style.input_inset = Opacity::from_fraction(0.5).unwrap();
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        let gtk = &css.gtk_css;
+        assert!(
+            gtk.contains("entry, entry.flat, spinbutton, spinbutton.flat"),
+            "{}: input-inset selector missing\n----\n{}",
+            generator.version_label(),
+            gtk,
+        );
+        // Both scheme blocks must be present — inputs should look
+        // depressed under both light and dark colour schemes.
+        assert!(
+            gtk.contains("mix(@view_bg_color, black,")
+                && gtk.contains("mix(@view_bg_color, white,"),
+            "{}: input-inset must emit both light-mode and dark-mode shifts",
+            generator.version_label(),
+        );
+    }
+}
+
+#[test]
+fn widget_button_raise_skips_flat_and_accent_variants() {
+    let mut spec = ThemeSpec::defaults();
+    spec.widget_style.button_raise = Opacity::from_fraction(0.6).unwrap();
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        let gtk = &css.gtk_css;
+        // The selector must carry all three :not() filters; otherwise
+        // we re-frame toolbar flat buttons and re-border the
+        // accent-filled suggested-action primary.
+        assert!(
+            gtk.contains("button:not(.flat):not(.suggested-action):not(.destructive-action)"),
+            "{}: button-raise selector missing or lacks scope filters\n----\n{}",
+            generator.version_label(),
+            gtk,
+        );
+        assert!(
+            gtk.contains(":active"),
+            "{}: button-raise missing :active pressed state",
+            generator.version_label(),
+        );
+    }
+}
+
+#[test]
+fn widget_headerbar_gradient_emits_both_schemes() {
+    let mut spec = ThemeSpec::defaults();
+    spec.widget_style.headerbar_gradient = Opacity::from_fraction(0.4).unwrap();
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        let gtk = &css.gtk_css;
+        assert!(
+            gtk.contains("headerbar, .toolbar"),
+            "{}: gradient rule must cover both headerbars and toolbars",
+            generator.version_label(),
+        );
+        assert!(
+            gtk.contains("linear-gradient(to bottom,"),
+            "{}: linear-gradient missing",
+            generator.version_label(),
+        );
+        // Light darkens at the bottom, dark lightens at the top — so
+        // both variants must contain mix-with-black *and* mix-with-white
+        // somewhere in the gradient block.
+        assert!(gtk.contains("mix(@headerbar_bg_color, black,"));
+        assert!(gtk.contains("mix(@headerbar_bg_color, white,"));
+    }
+}
+
+#[test]
+fn widget_style_all_three_knobs_compose() {
+    let mut spec = ThemeSpec::defaults();
+    spec.widget_style = WidgetStyleSpec {
+        input_inset: Opacity::from_fraction(0.5).unwrap(),
+        button_raise: Opacity::from_fraction(0.5).unwrap(),
+        headerbar_gradient: Opacity::from_fraction(0.5).unwrap(),
+    };
+    let generator = create_css_generator(&ShellVersion::new(47, 0));
+    let css = generator.generate(&spec).unwrap();
+    let gtk = &css.gtk_css;
+    assert!(gtk.contains("entry, entry.flat"));
+    assert!(gtk.contains("button:not(.flat)"));
+    assert!(gtk.contains("linear-gradient("));
+}

--- a/crates/ui/src/components/theme_builder.rs
+++ b/crates/ui/src/components/theme_builder.rs
@@ -12,7 +12,7 @@ use gnomex_app::use_cases::ApplyThemeUseCase;
 use gnomex_domain::theme_capability::{self, ThemeControlId};
 use gnomex_domain::{
     DashSpec, HexColor, LayerSeparationSpec, Opacity, PanelSpec, Radius, SidebarSpec, ThemeSpec,
-    TintSpec,
+    TintSpec, WidgetStyleSpec,
 };
 use relm4::prelude::*;
 use std::collections::HashMap;
@@ -65,6 +65,10 @@ pub struct ThemeBuilderModel {
     layer_headerbar_bottom: f64,
     layer_sidebar_divider: f64,
     layer_content_contrast: f64,
+    // Widget style (traditional-look opt-ins)
+    widget_input_inset: f64,
+    widget_button_raise: f64,
+    widget_headerbar_gradient: f64,
     // Notification
     notification_radius: f64,
     notification_opacity: f64,
@@ -139,6 +143,10 @@ pub enum ThemeBuilderMsg {
     SetLayerHeaderbarBottom(f64),
     SetLayerSidebarDivider(f64),
     SetLayerContentContrast(f64),
+    // Widget style
+    SetWidgetInputInset(f64),
+    SetWidgetButtonRaise(f64),
+    SetWidgetHeaderbarGradient(f64),
     // Notifications
     SetNotificationRadius(f64),
     SetNotificationOpacity(f64),
@@ -1401,6 +1409,64 @@ impl SimpleComponent for ThemeBuilderModel {
         }
         layer_group.add(&layer_cc_row);
 
+        // === Widget Style (traditional-look opt-ins) ===
+        let widget_style_group = adw::PreferencesGroup::builder()
+            .title("Widget Style")
+            .description(
+                "Restore traditional widget affordances. Adwaita defaults to \
+                 flat, chromeless widgets; dial these up if you prefer visible \
+                 buttons, inset inputs, or subtle headerbar gradients.",
+            )
+            .build();
+
+        let widget_input_row = build_spin_row(
+            "Input-Field Inset",
+            "Make entry fields look depressed (0 = flat Adwaita, 100% = strongly inset)",
+            0.0,
+            100.0,
+            app_settings.double("tb-widget-input-inset") * 100.0,
+            5.0,
+        );
+        {
+            let sender = sender.clone();
+            widget_input_row.connect_value_notify(move |row| {
+                sender.input(ThemeBuilderMsg::SetWidgetInputInset(row.value() / 100.0));
+            });
+        }
+        widget_style_group.add(&widget_input_row);
+
+        let widget_button_row = build_spin_row(
+            "Button Affordance",
+            "Add border + shadow so buttons read as pressable (0 = flat Adwaita, 100% = strongly raised)",
+            0.0,
+            100.0,
+            app_settings.double("tb-widget-button-raise") * 100.0,
+            5.0,
+        );
+        {
+            let sender = sender.clone();
+            widget_button_row.connect_value_notify(move |row| {
+                sender.input(ThemeBuilderMsg::SetWidgetButtonRaise(row.value() / 100.0));
+            });
+        }
+        widget_style_group.add(&widget_button_row);
+
+        let widget_gradient_row = build_spin_row(
+            "Headerbar Gradient",
+            "Subtle top-to-bottom gradient on headerbars (0 = flat, higher = more pronounced). Conflicts with Adwaita's flat philosophy.",
+            0.0,
+            100.0,
+            app_settings.double("tb-widget-headerbar-gradient") * 100.0,
+            5.0,
+        );
+        {
+            let sender = sender.clone();
+            widget_gradient_row.connect_value_notify(move |row| {
+                sender.input(ThemeBuilderMsg::SetWidgetHeaderbarGradient(row.value() / 100.0));
+            });
+        }
+        widget_style_group.add(&widget_gradient_row);
+
         // appended in final ordering
 
         // === Window Behavior (Mutter) ===
@@ -1545,7 +1611,7 @@ impl SimpleComponent for ThemeBuilderModel {
             &[&accent_group, &tint_group, &shared_group, &panel_group, &dash_group, &notif_group, &scheme_group],
         );
         let windows_page = build_category_page(
-            &[&radii_group, &csd_group, &inset_group, &sidebar_group, &layer_group, &window_group, &wm_group],
+            &[&radii_group, &csd_group, &inset_group, &sidebar_group, &layer_group, &widget_style_group, &window_group, &wm_group],
         );
         let typography_page = build_category_page(
             &[&font_group, &cursor_group],
@@ -1691,6 +1757,9 @@ impl SimpleComponent for ThemeBuilderModel {
             layer_headerbar_bottom: app_settings.double("tb-layer-headerbar-bottom"),
             layer_sidebar_divider: app_settings.double("tb-layer-sidebar-divider"),
             layer_content_contrast: app_settings.double("tb-layer-content-contrast"),
+            widget_input_inset: app_settings.double("tb-widget-input-inset"),
+            widget_button_raise: app_settings.double("tb-widget-button-raise"),
+            widget_headerbar_gradient: app_settings.double("tb-widget-headerbar-gradient"),
             notification_radius: app_settings.double("tb-notification-radius"),
             notification_opacity: app_settings.double("tb-notification-opacity"),
             scheduled_accent_enabled: saved_sched_enabled,
@@ -2108,6 +2177,10 @@ impl SimpleComponent for ThemeBuilderModel {
             ThemeBuilderMsg::SetLayerHeaderbarBottom(v) => self.layer_headerbar_bottom = v,
             ThemeBuilderMsg::SetLayerSidebarDivider(v) => self.layer_sidebar_divider = v,
             ThemeBuilderMsg::SetLayerContentContrast(v) => self.layer_content_contrast = v,
+            // --- Widget style ---
+            ThemeBuilderMsg::SetWidgetInputInset(v) => self.widget_input_inset = v,
+            ThemeBuilderMsg::SetWidgetButtonRaise(v) => self.widget_button_raise = v,
+            ThemeBuilderMsg::SetWidgetHeaderbarGradient(v) => self.widget_headerbar_gradient = v,
             // --- Notifications ---
             ThemeBuilderMsg::SetNotificationRadius(v) => self.notification_radius = v,
             ThemeBuilderMsg::SetNotificationOpacity(v) => self.notification_opacity = v,
@@ -2270,6 +2343,12 @@ impl SimpleComponent for ThemeBuilderModel {
                 let _ = app.set_double("tb-layer-headerbar-bottom", self.layer_headerbar_bottom);
                 let _ = app.set_double("tb-layer-sidebar-divider", self.layer_sidebar_divider);
                 let _ = app.set_double("tb-layer-content-contrast", self.layer_content_contrast);
+                let _ = app.set_double("tb-widget-input-inset", self.widget_input_inset);
+                let _ = app.set_double("tb-widget-button-raise", self.widget_button_raise);
+                let _ = app.set_double(
+                    "tb-widget-headerbar-gradient",
+                    self.widget_headerbar_gradient,
+                );
                 let _ = app.set_double("tb-notification-radius", self.notification_radius);
                 let _ = app.set_double("tb-notification-opacity", self.notification_opacity);
 
@@ -2307,6 +2386,9 @@ impl SimpleComponent for ThemeBuilderModel {
                 self.layer_headerbar_bottom = 0.0;
                 self.layer_sidebar_divider = 0.0;
                 self.layer_content_contrast = 0.0;
+                self.widget_input_inset = 0.0;
+                self.widget_button_raise = 0.0;
+                self.widget_headerbar_gradient = 0.0;
 
                 let _ = self.apply_uc.reset();
                 let _ = sender
@@ -2356,6 +2438,11 @@ impl ThemeBuilderModel {
                 headerbar_bottom: Radius::new(self.layer_headerbar_bottom)?,
                 sidebar_divider: Radius::new(self.layer_sidebar_divider)?,
                 content_contrast: Opacity::from_fraction(self.layer_content_contrast)?,
+            },
+            widget_style: WidgetStyleSpec {
+                input_inset: Opacity::from_fraction(self.widget_input_inset)?,
+                button_raise: Opacity::from_fraction(self.widget_button_raise)?,
+                headerbar_gradient: Opacity::from_fraction(self.widget_headerbar_gradient)?,
             },
             sidebar: SidebarSpec {
                 opacity: Opacity::from_fraction(self.sidebar_opacity)?,

--- a/data/io.github.gnomex.GnomeX.gschema.xml
+++ b/data/io.github.gnomex.GnomeX.gschema.xml
@@ -124,6 +124,21 @@
       <default>true</default>
       <summary>Show combo button inset border</summary>
     </key>
+    <key name="tb-widget-input-inset" type="d">
+      <default>0.0</default>
+      <summary>Input-field inset intensity</summary>
+      <description>0.0 = Adwaita-flat inputs. Higher values give entries a visible background and border so they read as clearly depressed.</description>
+    </key>
+    <key name="tb-widget-button-raise" type="d">
+      <default>0.0</default>
+      <summary>Button-affordance raise intensity</summary>
+      <description>0.0 = Adwaita-flat buttons. Higher values give non-flat, non-suggested buttons a border and shadow so they read as pressable.</description>
+    </key>
+    <key name="tb-widget-headerbar-gradient" type="d">
+      <default>0.0</default>
+      <summary>Headerbar gradient intensity</summary>
+      <description>0.0 = flat Adwaita headerbar. Higher values apply a subtle top-to-bottom gradient. Conflicts with Adwaita's flat philosophy; use sparingly.</description>
+    </key>
     <key name="tb-layer-headerbar-bottom" type="d">
       <default>0.0</default>
       <summary>Headerbar bottom-border width (px)</summary>


### PR DESCRIPTION
## Summary

Three opt-in intensity knobs to restore traditional widget affordances against the flat Libadwaita baseline:

1. **Input-Field Inset** — `entry, entry.flat, spinbutton` gain a visibly tinted background, border, and top-inset shadow. Darkens in light mode, lightens in dark mode.
2. **Button Affordance** — `button:not(.flat):not(.suggested-action):not(.destructive-action)` gains a border + shadow + `:active` pressed state.
3. **Headerbar Gradient** — `headerbar, .toolbar` gets a subtle top→bottom `linear-gradient`. Light darkens toward the bottom; dark lightens toward the top.

## Why

Three separate tracker items all asked for variations of "give me back traditional widget chrome." Landing them as one `WidgetStyleSpec` keeps the knobs on the same 0–100 % UI scale, shares a single opt-in default policy (all zeroes = byte-identical output), and avoids three near-duplicate spec structs.

The `:not()` filters on the button selector are **load-bearing** — without them, flat toolbar buttons get re-framed and the accent-filled suggested-action primary gets an extra border, both of which look broken. A test pins those filters.

## Scope trade-offs

- **Intensity rather than style.** One continuous knob per effect, not a stylistic matrix. Keeps UI and spec small. Users who want "Win98 buttons" or exactly a 2-px groove can hand-edit after the fact.
- **Gradient is deliberately bounded.** Even knob=1.0 produces a subtle delta (≈0.09). Headerbar gradients fight the Adwaita philosophy and the row subtitle calls that out.

## Test plan

- [x] `cargo test --workspace` passes.
- [x] `cargo test --test widget_style_css` — 5/5 pass.
- [x] `glib-compile-schemas --strict --dry-run data/` validates the new keys.
- [x] `cargo build -p gnomex-ui` compiles the new PreferencesGroup.
- [x] Manually verify: input-inset at 50 %, entries in Settings read as depressed. Apply to dark mode, still look depressed.
- [x] Manually verify: button-raise at 50 %, toolbar buttons (flat) stay flat; suggested-action primary keeps its accent fill; regular buttons gain border + shadow.

Closes #16
Closes #17
Closes #18