### PR TITLE
feat: add per-widget, per-scheme background colour overrides

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -15,7 +15,7 @@ use gnomex_app::use_cases::{ApplyThemeUseCase, CustomizeShellUseCase, PacksUseCa
 use gnomex_domain::{
     DashSpec, ForegroundSpec, HeaderbarSpec, HexColor, InsetSpec, LayerSeparationSpec,
     NotificationSpec, Opacity, PanelSpec, Radius, SidebarSpec, StatusColorSpec, ThemeSpec,
-    TintSpec, WidgetStyleSpec, WindowFrameSpec,
+    TintSpec, WidgetColorOverrides, WidgetStyleSpec, WindowFrameSpec,
 };
 use gnomex_infra::{
     ChromiumThemer, DbusShellProxy, EgoClient, FilesystemInstaller, FilesystemThemeWriter,
@@ -355,6 +355,16 @@ fn build_spec_from_gsettings() -> Result<ThemeSpec> {
             button_raise: Opacity::from_fraction(app.double("tb-widget-button-raise"))?,
             headerbar_gradient: Opacity::from_fraction(app.double("tb-widget-headerbar-gradient"))?,
         },
+        widget_colors: WidgetColorOverrides {
+            button_bg_light: parse_optional_hex(&app.string("tb-color-button-bg-light"))?,
+            button_bg_dark: parse_optional_hex(&app.string("tb-color-button-bg-dark"))?,
+            entry_bg_light: parse_optional_hex(&app.string("tb-color-entry-bg-light"))?,
+            entry_bg_dark: parse_optional_hex(&app.string("tb-color-entry-bg-dark"))?,
+            headerbar_bg_light: parse_optional_hex(&app.string("tb-color-headerbar-bg-light"))?,
+            headerbar_bg_dark: parse_optional_hex(&app.string("tb-color-headerbar-bg-dark"))?,
+            sidebar_bg_light: parse_optional_hex(&app.string("tb-color-sidebar-bg-light"))?,
+            sidebar_bg_dark: parse_optional_hex(&app.string("tb-color-sidebar-bg-dark"))?,
+        },
         sidebar: SidebarSpec {
             opacity: Opacity::from_fraction(app.double("tb-sidebar-opacity"))?,
             fg_override: {
@@ -374,6 +384,15 @@ fn build_spec_from_gsettings() -> Result<ThemeSpec> {
         },
         overview_blur: app.boolean("tb-overview-blur"),
     })
+}
+
+fn parse_optional_hex(raw: &str) -> Result<Option<HexColor>> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(HexColor::new(trimmed).context("invalid hex override")?))
+    }
 }
 
 fn accent_name_to_hex(name: &str) -> String {

--- a/crates/domain/src/theme_spec.rs
+++ b/crates/domain/src/theme_spec.rs
@@ -230,6 +230,37 @@ impl Default for SidebarSpec {
     }
 }
 
+/// Per-widget, per-scheme background-colour overrides.
+///
+/// Each field is scoped by `@media (prefers-color-scheme: ...)` so the
+/// user can, for example, dial a warm orange button in light mode and
+/// a cool blue button in dark mode. `None` means "follow the current
+/// Adwaita / tinting behaviour unchanged".
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct WidgetColorOverrides {
+    pub button_bg_light: Option<HexColor>,
+    pub button_bg_dark: Option<HexColor>,
+    pub entry_bg_light: Option<HexColor>,
+    pub entry_bg_dark: Option<HexColor>,
+    pub headerbar_bg_light: Option<HexColor>,
+    pub headerbar_bg_dark: Option<HexColor>,
+    pub sidebar_bg_light: Option<HexColor>,
+    pub sidebar_bg_dark: Option<HexColor>,
+}
+
+impl WidgetColorOverrides {
+    pub fn is_empty(&self) -> bool {
+        self.button_bg_light.is_none()
+            && self.button_bg_dark.is_none()
+            && self.entry_bg_light.is_none()
+            && self.entry_bg_dark.is_none()
+            && self.headerbar_bg_light.is_none()
+            && self.headerbar_bg_dark.is_none()
+            && self.sidebar_bg_light.is_none()
+            && self.sidebar_bg_dark.is_none()
+    }
+}
+
 /// Semantic status color overrides (None = use Adwaita defaults).
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct StatusColorSpec {
@@ -265,6 +296,7 @@ pub struct ThemeSpec {
     pub sidebar: SidebarSpec,
     pub layers: LayerSeparationSpec,
     pub widget_style: WidgetStyleSpec,
+    pub widget_colors: WidgetColorOverrides,
     pub status_colors: StatusColorSpec,
     pub notifications: NotificationSpec,
     pub overview_blur: bool,
@@ -306,6 +338,7 @@ impl ThemeSpec {
             sidebar: SidebarSpec::default(),
             layers: LayerSeparationSpec::default(),
             widget_style: WidgetStyleSpec::default(),
+            widget_colors: WidgetColorOverrides::default(),
             status_colors: StatusColorSpec::default(),
             notifications: NotificationSpec {
                 radius: Radius(12.0),

--- a/crates/infra/src/theme_css/common.rs
+++ b/crates/infra/src/theme_css/common.rs
@@ -272,6 +272,53 @@ pub fn gtk_layer_separation_css(spec: &ThemeSpec) -> String {
     out
 }
 
+/// Generate per-widget, per-scheme `@define-color` overrides that
+/// supersede the accent-tinted defaults emitted by `gtk_tint_css`.
+///
+/// Must be concatenated AFTER `gtk_tint_css` — `@define-color` is
+/// last-wins, so a later redefinition beats the accent mix.
+///
+/// Emits an empty string when no override is set, so default themes
+/// pay zero bytes.
+pub fn gtk_widget_color_overrides_css(spec: &ThemeSpec) -> String {
+    let w = &spec.widget_colors;
+    if w.is_empty() {
+        return String::new();
+    }
+
+    let mut light = String::new();
+    let mut dark = String::new();
+
+    fn push(scope: &mut String, token: &str, v: &Option<HexColor>) {
+        if let Some(c) = v {
+            scope.push_str(&format!("    @define-color {token} {};\n", c.as_str()));
+        }
+    }
+
+    push(&mut light, "button_bg_color", &w.button_bg_light);
+    push(&mut light, "entry_bg_color", &w.entry_bg_light);
+    push(&mut light, "headerbar_bg_color", &w.headerbar_bg_light);
+    push(&mut light, "sidebar_bg_color", &w.sidebar_bg_light);
+
+    push(&mut dark, "button_bg_color", &w.button_bg_dark);
+    push(&mut dark, "entry_bg_color", &w.entry_bg_dark);
+    push(&mut dark, "headerbar_bg_color", &w.headerbar_bg_dark);
+    push(&mut dark, "sidebar_bg_color", &w.sidebar_bg_dark);
+
+    let mut out = String::from("/* Per-widget colour overrides */\n");
+    if !light.is_empty() {
+        out.push_str("@media (prefers-color-scheme: light) {\n");
+        out.push_str(&light);
+        out.push_str("}\n");
+    }
+    if !dark.is_empty() {
+        out.push_str("@media (prefers-color-scheme: dark) {\n");
+        out.push_str(&dark);
+        out.push_str("}\n");
+    }
+    out
+}
+
 /// Generate CSS for foreground/text and semantic status color overrides.
 pub fn gtk_color_overrides_css(spec: &ThemeSpec) -> String {
     let mut css = String::new();

--- a/crates/infra/src/theme_css/gnome45.rs
+++ b/crates/infra/src/theme_css/gnome45.rs
@@ -6,7 +6,7 @@
 
 use super::common::{
     gtk_color_overrides_css, gtk_csd_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
-    gtk_widget_style_css, tint_shell_surfaces,
+    gtk_widget_color_overrides_css, gtk_widget_style_css, tint_shell_surfaces,
 };
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
@@ -30,13 +30,14 @@ impl ThemeCssGenerator for Gnome45CssGenerator {
 impl Gnome45CssGenerator {
     fn gtk(&self, spec: &ThemeSpec) -> String {
         format!(
-            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
             gtk_layer_separation_css(spec),
             gtk_widget_style_css(spec),
             gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
+            gtk_widget_color_overrides_css(spec),
         )
     }
 

--- a/crates/infra/src/theme_css/gnome46.rs
+++ b/crates/infra/src/theme_css/gnome46.rs
@@ -6,7 +6,7 @@
 
 use super::common::{
     gtk_color_overrides_css, gtk_csd_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
-    gtk_widget_style_css, tint_shell_surfaces,
+    gtk_widget_color_overrides_css, gtk_widget_style_css, tint_shell_surfaces,
 };
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
@@ -30,13 +30,14 @@ impl ThemeCssGenerator for Gnome46CssGenerator {
 impl Gnome46CssGenerator {
     fn gtk(&self, spec: &ThemeSpec) -> String {
         format!(
-            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
             gtk_layer_separation_css(spec),
             gtk_widget_style_css(spec),
             gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
+            gtk_widget_color_overrides_css(spec),
         )
     }
 

--- a/crates/infra/src/theme_css/gnome47.rs
+++ b/crates/infra/src/theme_css/gnome47.rs
@@ -7,7 +7,8 @@
 
 use super::common::{
     gtk_csd_css, gtk_color_overrides_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
-    gtk_widget_style_css, shell_notification_css, tint_shell_surfaces,
+    gtk_widget_color_overrides_css, gtk_widget_style_css, shell_notification_css,
+    tint_shell_surfaces,
 };
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
@@ -31,13 +32,14 @@ impl ThemeCssGenerator for Gnome47CssGenerator {
 impl Gnome47CssGenerator {
     fn gtk(&self, spec: &ThemeSpec) -> String {
         format!(
-            "/* GNOME X — GTK4 overrides (GNOME 47+) */\n\n{}\n{}\n{}\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides (GNOME 47+) */\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
             gtk_layer_separation_css(spec),
             gtk_widget_style_css(spec),
             gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
+            gtk_widget_color_overrides_css(spec),
         )
     }
 

--- a/crates/infra/src/theme_css/gnome50.rs
+++ b/crates/infra/src/theme_css/gnome50.rs
@@ -11,7 +11,7 @@
 
 use super::common::{
     gtk_color_overrides_css, gtk_csd_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
-    gtk_widget_style_css,
+    gtk_widget_color_overrides_css, gtk_widget_style_css,
 };
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
@@ -46,13 +46,14 @@ impl Gnome50CssGenerator {
         // No style-dark.css generation — Libadwaita 1.9 logs deprecation
         // warnings if it finds separate dark variant files.
         format!(
-            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}\n{}",
+            "/* GNOME X — GTK4 overrides */\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
             gtk_radius_css(spec),
             gtk_csd_css(spec),
             gtk_layer_separation_css(spec),
             gtk_widget_style_css(spec),
             gtk_color_overrides_css(spec),
             gtk_tint_css(spec),
+            gtk_widget_color_overrides_css(spec),
         )
     }
 

--- a/crates/infra/tests/widget_color_overrides.rs
+++ b/crates/infra/tests/widget_color_overrides.rs
@@ -1,0 +1,147 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-widget, per-scheme colour override fixtures (GXF-040).
+//!
+//! `WidgetColorOverrides` lets the user pin button / entry / headerbar /
+//! sidebar backgrounds for light mode and dark mode independently. The
+//! critical invariants this test pins:
+//!
+//! 1. **Opt-in.** No fields set = zero override CSS emitted, so default
+//!    themes stay byte-compatible.
+//! 2. **Last-wins ordering.** The override block must appear *after*
+//!    the accent-tint block so a later `@define-color` redefinition
+//!    actually beats the tint default. (CSS `@define-color` is
+//!    last-wins in Libadwaita.)
+//! 3. **Scheme isolation.** A light-only override must not leak into
+//!    the dark block, and vice-versa. Otherwise users who set a warm
+//!    button in light mode get the same warm button fighting a dark
+//!    wallpaper at night.
+//! 4. **Version-universal.** Overrides fire on every supported GNOME
+//!    version — the feature shouldn't regress on version bumps.
+
+use gnomex_domain::{HexColor, ShellVersion, ThemeSpec, WidgetColorOverrides};
+use gnomex_infra::theme_css::create_css_generator;
+
+fn all_supported_versions() -> Vec<ShellVersion> {
+    vec![
+        ShellVersion::new(45, 0),
+        ShellVersion::new(46, 0),
+        ShellVersion::new(47, 0),
+        ShellVersion::new(50, 0),
+    ]
+}
+
+#[test]
+fn widget_colors_default_emits_no_override_block() {
+    let spec = ThemeSpec::defaults();
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        assert!(
+            !css.gtk_css.contains("Per-widget colour overrides"),
+            "{}: default spec emitted an override block — must be opt-in",
+            generator.version_label(),
+        );
+    }
+}
+
+#[test]
+fn widget_colors_light_only_does_not_leak_into_dark() {
+    let mut spec = ThemeSpec::defaults();
+    spec.widget_colors = WidgetColorOverrides {
+        button_bg_light: Some(HexColor::new("#ffaa22").unwrap()),
+        ..Default::default()
+    };
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        let (light, dark) = split_scopes_after_override(&css.gtk_css)
+            .unwrap_or_else(|| panic!("{}: scopes missing", generator.version_label()));
+        assert!(
+            light.contains("@define-color button_bg_color #ffaa22"),
+            "{}: light-mode override missing\n----\n{light}",
+            generator.version_label(),
+        );
+        assert!(
+            !dark.contains("button_bg_color #ffaa22"),
+            "{}: light-mode override leaked into dark scope\n----\n{dark}",
+            generator.version_label(),
+        );
+    }
+}
+
+#[test]
+fn widget_colors_all_widgets_emit_all_eight_slots() {
+    let mut spec = ThemeSpec::defaults();
+    spec.widget_colors = WidgetColorOverrides {
+        button_bg_light: Some(HexColor::new("#ff0001").unwrap()),
+        button_bg_dark: Some(HexColor::new("#ff0002").unwrap()),
+        entry_bg_light: Some(HexColor::new("#ff0003").unwrap()),
+        entry_bg_dark: Some(HexColor::new("#ff0004").unwrap()),
+        headerbar_bg_light: Some(HexColor::new("#ff0005").unwrap()),
+        headerbar_bg_dark: Some(HexColor::new("#ff0006").unwrap()),
+        sidebar_bg_light: Some(HexColor::new("#ff0007").unwrap()),
+        sidebar_bg_dark: Some(HexColor::new("#ff0008").unwrap()),
+    };
+    let generator = create_css_generator(&ShellVersion::new(47, 0));
+    let css = generator.generate(&spec).unwrap();
+    let gtk = &css.gtk_css;
+    for hex in &[
+        "#ff0001", "#ff0002", "#ff0003", "#ff0004", "#ff0005", "#ff0006", "#ff0007", "#ff0008",
+    ] {
+        assert!(
+            gtk.contains(hex),
+            "missing override hex `{hex}`\n----\n{gtk}",
+        );
+    }
+}
+
+#[test]
+fn widget_colors_override_block_appears_after_tint_block() {
+    // If the override block lands *before* the tint block, the tint's
+    // later `@define-color sidebar_bg_color mix(...)` wins and the
+    // user's override silently does nothing. Pin the ordering.
+    let mut spec = ThemeSpec::defaults();
+    spec.widget_colors.sidebar_bg_light = Some(HexColor::new("#deadbe").unwrap());
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        let gtk = &css.gtk_css;
+
+        let tint_pos = gtk
+            .find("/* Accent-tinted surfaces */")
+            .unwrap_or_else(|| panic!("{}: accent tint block missing", generator.version_label()));
+        let override_pos = gtk
+            .find("/* Per-widget colour overrides */")
+            .unwrap_or_else(|| panic!("{}: override block missing", generator.version_label()));
+
+        assert!(
+            override_pos > tint_pos,
+            "{}: override block (pos {override_pos}) must come AFTER tint block (pos {tint_pos}) — @define-color is last-wins",
+            generator.version_label(),
+        );
+    }
+}
+
+// -- helpers ------------------------------------------------------------
+
+/// Isolate the override block's two `@media` scopes so we can assert
+/// one scheme contains the override and the other doesn't.
+fn split_scopes_after_override(gtk: &str) -> Option<(String, String)> {
+    let start = gtk.find("/* Per-widget colour overrides */")?;
+    let block = &gtk[start..];
+    let light = block.find("prefers-color-scheme: light")?;
+    let dark = block.find("prefers-color-scheme: dark");
+    let light_slice = if let Some(dark_pos) = dark {
+        &block[light..dark_pos]
+    } else {
+        &block[light..]
+    };
+    let dark_slice = if let Some(dark_pos) = dark {
+        &block[dark_pos..]
+    } else {
+        ""
+    };
+    Some((light_slice.to_string(), dark_slice.to_string()))
+}

--- a/crates/ui/src/components/theme_builder.rs
+++ b/crates/ui/src/components/theme_builder.rs
@@ -12,7 +12,7 @@ use gnomex_app::use_cases::ApplyThemeUseCase;
 use gnomex_domain::theme_capability::{self, ThemeControlId};
 use gnomex_domain::{
     DashSpec, HexColor, LayerSeparationSpec, Opacity, PanelSpec, Radius, SidebarSpec, ThemeSpec,
-    TintSpec, WidgetStyleSpec,
+    TintSpec, WidgetColorOverrides, WidgetStyleSpec,
 };
 use relm4::prelude::*;
 use std::collections::HashMap;
@@ -69,6 +69,15 @@ pub struct ThemeBuilderModel {
     widget_input_inset: f64,
     widget_button_raise: f64,
     widget_headerbar_gradient: f64,
+    // Per-widget, per-scheme background colour overrides (hex strings; "" = none)
+    color_button_bg_light: String,
+    color_button_bg_dark: String,
+    color_entry_bg_light: String,
+    color_entry_bg_dark: String,
+    color_headerbar_bg_light: String,
+    color_headerbar_bg_dark: String,
+    color_sidebar_bg_light: String,
+    color_sidebar_bg_dark: String,
     // Notification
     notification_radius: f64,
     notification_opacity: f64,
@@ -98,6 +107,20 @@ pub struct ThemeBuilderModel {
     day_panel_row: adw::ActionRow,
     night_panel_row: adw::ActionRow,
     compat_rows: HashMap<ThemeControlId, (adw::SpinRow, String)>, // (row, original_subtitle)
+}
+
+/// Which per-widget, per-scheme colour slot a `SetWidgetColor` message
+/// targets.
+#[derive(Debug, Clone, Copy)]
+pub enum WidgetColorTarget {
+    ButtonLight,
+    ButtonDark,
+    EntryLight,
+    EntryDark,
+    HeaderbarLight,
+    HeaderbarDark,
+    SidebarLight,
+    SidebarDark,
 }
 
 #[derive(Debug)]
@@ -147,6 +170,8 @@ pub enum ThemeBuilderMsg {
     SetWidgetInputInset(f64),
     SetWidgetButtonRaise(f64),
     SetWidgetHeaderbarGradient(f64),
+    // Per-widget colour overrides (scheme, widget, hex-or-empty)
+    SetWidgetColor(WidgetColorTarget, String),
     // Notifications
     SetNotificationRadius(f64),
     SetNotificationOpacity(f64),
@@ -1467,6 +1492,136 @@ impl SimpleComponent for ThemeBuilderModel {
         }
         widget_style_group.add(&widget_gradient_row);
 
+        // === Widget Colours (per-widget, per-scheme) ===
+        let widget_colors_group = adw::PreferencesGroup::builder()
+            .title("Widget Colours")
+            .description(
+                "Override specific widget backgrounds for light and dark \
+                 mode independently. Each slot supersedes the accent-tint \
+                 default. Reset to remove an override.",
+            )
+            .build();
+
+        let make_color_pair_row = |title: &str,
+                                   subtitle: &str,
+                                   light_target: WidgetColorTarget,
+                                   dark_target: WidgetColorTarget,
+                                   light_key: &str,
+                                   dark_key: &str|
+         -> adw::ActionRow {
+            let row = adw::ActionRow::builder()
+                .title(title)
+                .subtitle(subtitle)
+                .build();
+
+            let light_btn = gtk::ColorDialogButton::builder().tooltip_text("Light mode").build();
+            light_btn.set_dialog(
+                &gtk::ColorDialog::builder()
+                    .title(format!("{title} (light)"))
+                    .with_alpha(false)
+                    .build(),
+            );
+            let saved_light = app_settings.string(light_key).to_string();
+            if !saved_light.is_empty() {
+                if let Ok(rgba) = gtk::gdk::RGBA::parse(&saved_light) {
+                    light_btn.set_rgba(&rgba);
+                }
+            }
+
+            let dark_btn = gtk::ColorDialogButton::builder().tooltip_text("Dark mode").build();
+            dark_btn.set_dialog(
+                &gtk::ColorDialog::builder()
+                    .title(format!("{title} (dark)"))
+                    .with_alpha(false)
+                    .build(),
+            );
+            let saved_dark = app_settings.string(dark_key).to_string();
+            if !saved_dark.is_empty() {
+                if let Ok(rgba) = gtk::gdk::RGBA::parse(&saved_dark) {
+                    dark_btn.set_rgba(&rgba);
+                }
+            }
+
+            let reset_btn = gtk::Button::builder()
+                .icon_name("edit-clear-symbolic")
+                .valign(gtk::Align::Center)
+                .css_classes(["flat"])
+                .tooltip_text("Clear both overrides")
+                .build();
+
+            {
+                let sender = sender.clone();
+                light_btn.connect_rgba_notify(move |btn| {
+                    let rgba = btn.rgba();
+                    let hex = format!(
+                        "#{:02x}{:02x}{:02x}",
+                        (rgba.red() * 255.0) as u8,
+                        (rgba.green() * 255.0) as u8,
+                        (rgba.blue() * 255.0) as u8,
+                    );
+                    sender.input(ThemeBuilderMsg::SetWidgetColor(light_target, hex));
+                });
+            }
+            {
+                let sender = sender.clone();
+                dark_btn.connect_rgba_notify(move |btn| {
+                    let rgba = btn.rgba();
+                    let hex = format!(
+                        "#{:02x}{:02x}{:02x}",
+                        (rgba.red() * 255.0) as u8,
+                        (rgba.green() * 255.0) as u8,
+                        (rgba.blue() * 255.0) as u8,
+                    );
+                    sender.input(ThemeBuilderMsg::SetWidgetColor(dark_target, hex));
+                });
+            }
+            {
+                let sender = sender.clone();
+                reset_btn.connect_clicked(move |_| {
+                    sender.input(ThemeBuilderMsg::SetWidgetColor(light_target, String::new()));
+                    sender.input(ThemeBuilderMsg::SetWidgetColor(dark_target, String::new()));
+                });
+            }
+
+            row.add_suffix(&light_btn);
+            row.add_suffix(&dark_btn);
+            row.add_suffix(&reset_btn);
+            row
+        };
+
+        widget_colors_group.add(&make_color_pair_row(
+            "Button Background",
+            "Sets @button_bg_color (light & dark)",
+            WidgetColorTarget::ButtonLight,
+            WidgetColorTarget::ButtonDark,
+            "tb-color-button-bg-light",
+            "tb-color-button-bg-dark",
+        ));
+        widget_colors_group.add(&make_color_pair_row(
+            "Input Background",
+            "Sets @entry_bg_color (light & dark)",
+            WidgetColorTarget::EntryLight,
+            WidgetColorTarget::EntryDark,
+            "tb-color-entry-bg-light",
+            "tb-color-entry-bg-dark",
+        ));
+        widget_colors_group.add(&make_color_pair_row(
+            "Headerbar Background",
+            "Sets @headerbar_bg_color (light & dark)",
+            WidgetColorTarget::HeaderbarLight,
+            WidgetColorTarget::HeaderbarDark,
+            "tb-color-headerbar-bg-light",
+            "tb-color-headerbar-bg-dark",
+        ));
+        widget_colors_group.add(&make_color_pair_row(
+            "Sidebar Background",
+            "Sets @sidebar_bg_color (light & dark)",
+            WidgetColorTarget::SidebarLight,
+            WidgetColorTarget::SidebarDark,
+            "tb-color-sidebar-bg-light",
+            "tb-color-sidebar-bg-dark",
+        ));
+
         // appended in final ordering
 
         // === Window Behavior (Mutter) ===
@@ -1611,7 +1766,7 @@ impl SimpleComponent for ThemeBuilderModel {
             &[&accent_group, &tint_group, &shared_group, &panel_group, &dash_group, &notif_group, &scheme_group],
         );
         let windows_page = build_category_page(
-            &[&radii_group, &csd_group, &inset_group, &sidebar_group, &layer_group, &widget_style_group, &window_group, &wm_group],
+            &[&radii_group, &csd_group, &inset_group, &sidebar_group, &layer_group, &widget_style_group, &widget_colors_group, &window_group, &wm_group],
         );
         let typography_page = build_category_page(
             &[&font_group, &cursor_group],
@@ -1760,6 +1915,14 @@ impl SimpleComponent for ThemeBuilderModel {
             widget_input_inset: app_settings.double("tb-widget-input-inset"),
             widget_button_raise: app_settings.double("tb-widget-button-raise"),
             widget_headerbar_gradient: app_settings.double("tb-widget-headerbar-gradient"),
+            color_button_bg_light: app_settings.string("tb-color-button-bg-light").into(),
+            color_button_bg_dark: app_settings.string("tb-color-button-bg-dark").into(),
+            color_entry_bg_light: app_settings.string("tb-color-entry-bg-light").into(),
+            color_entry_bg_dark: app_settings.string("tb-color-entry-bg-dark").into(),
+            color_headerbar_bg_light: app_settings.string("tb-color-headerbar-bg-light").into(),
+            color_headerbar_bg_dark: app_settings.string("tb-color-headerbar-bg-dark").into(),
+            color_sidebar_bg_light: app_settings.string("tb-color-sidebar-bg-light").into(),
+            color_sidebar_bg_dark: app_settings.string("tb-color-sidebar-bg-dark").into(),
             notification_radius: app_settings.double("tb-notification-radius"),
             notification_opacity: app_settings.double("tb-notification-opacity"),
             scheduled_accent_enabled: saved_sched_enabled,
@@ -2181,6 +2344,17 @@ impl SimpleComponent for ThemeBuilderModel {
             ThemeBuilderMsg::SetWidgetInputInset(v) => self.widget_input_inset = v,
             ThemeBuilderMsg::SetWidgetButtonRaise(v) => self.widget_button_raise = v,
             ThemeBuilderMsg::SetWidgetHeaderbarGradient(v) => self.widget_headerbar_gradient = v,
+            // --- Per-widget colour overrides ---
+            ThemeBuilderMsg::SetWidgetColor(target, hex) => match target {
+                WidgetColorTarget::ButtonLight => self.color_button_bg_light = hex,
+                WidgetColorTarget::ButtonDark => self.color_button_bg_dark = hex,
+                WidgetColorTarget::EntryLight => self.color_entry_bg_light = hex,
+                WidgetColorTarget::EntryDark => self.color_entry_bg_dark = hex,
+                WidgetColorTarget::HeaderbarLight => self.color_headerbar_bg_light = hex,
+                WidgetColorTarget::HeaderbarDark => self.color_headerbar_bg_dark = hex,
+                WidgetColorTarget::SidebarLight => self.color_sidebar_bg_light = hex,
+                WidgetColorTarget::SidebarDark => self.color_sidebar_bg_dark = hex,
+            },
             // --- Notifications ---
             ThemeBuilderMsg::SetNotificationRadius(v) => self.notification_radius = v,
             ThemeBuilderMsg::SetNotificationOpacity(v) => self.notification_opacity = v,
@@ -2349,6 +2523,20 @@ impl SimpleComponent for ThemeBuilderModel {
                     "tb-widget-headerbar-gradient",
                     self.widget_headerbar_gradient,
                 );
+                let _ = app.set_string("tb-color-button-bg-light", &self.color_button_bg_light);
+                let _ = app.set_string("tb-color-button-bg-dark", &self.color_button_bg_dark);
+                let _ = app.set_string("tb-color-entry-bg-light", &self.color_entry_bg_light);
+                let _ = app.set_string("tb-color-entry-bg-dark", &self.color_entry_bg_dark);
+                let _ = app.set_string(
+                    "tb-color-headerbar-bg-light",
+                    &self.color_headerbar_bg_light,
+                );
+                let _ = app.set_string(
+                    "tb-color-headerbar-bg-dark",
+                    &self.color_headerbar_bg_dark,
+                );
+                let _ = app.set_string("tb-color-sidebar-bg-light", &self.color_sidebar_bg_light);
+                let _ = app.set_string("tb-color-sidebar-bg-dark", &self.color_sidebar_bg_dark);
                 let _ = app.set_double("tb-notification-radius", self.notification_radius);
                 let _ = app.set_double("tb-notification-opacity", self.notification_opacity);
 
@@ -2389,6 +2577,14 @@ impl SimpleComponent for ThemeBuilderModel {
                 self.widget_input_inset = 0.0;
                 self.widget_button_raise = 0.0;
                 self.widget_headerbar_gradient = 0.0;
+                self.color_button_bg_light = String::new();
+                self.color_button_bg_dark = String::new();
+                self.color_entry_bg_light = String::new();
+                self.color_entry_bg_dark = String::new();
+                self.color_headerbar_bg_light = String::new();
+                self.color_headerbar_bg_dark = String::new();
+                self.color_sidebar_bg_light = String::new();
+                self.color_sidebar_bg_dark = String::new();
 
                 let _ = self.apply_uc.reset();
                 let _ = sender
@@ -2444,6 +2640,16 @@ impl ThemeBuilderModel {
                 button_raise: Opacity::from_fraction(self.widget_button_raise)?,
                 headerbar_gradient: Opacity::from_fraction(self.widget_headerbar_gradient)?,
             },
+            widget_colors: WidgetColorOverrides {
+                button_bg_light: parse_optional_hex(&self.color_button_bg_light)?,
+                button_bg_dark: parse_optional_hex(&self.color_button_bg_dark)?,
+                entry_bg_light: parse_optional_hex(&self.color_entry_bg_light)?,
+                entry_bg_dark: parse_optional_hex(&self.color_entry_bg_dark)?,
+                headerbar_bg_light: parse_optional_hex(&self.color_headerbar_bg_light)?,
+                headerbar_bg_dark: parse_optional_hex(&self.color_headerbar_bg_dark)?,
+                sidebar_bg_light: parse_optional_hex(&self.color_sidebar_bg_light)?,
+                sidebar_bg_dark: parse_optional_hex(&self.color_sidebar_bg_dark)?,
+            },
             sidebar: SidebarSpec {
                 opacity: Opacity::from_fraction(self.sidebar_opacity)?,
                 fg_override: {
@@ -2462,6 +2668,17 @@ impl ThemeBuilderModel {
             },
             overview_blur: self.overview_blur,
         })
+    }
+}
+
+/// Parse a user-supplied hex string that may be empty, trimming
+/// whitespace and treating "" as "no override".
+fn parse_optional_hex(raw: &str) -> Result<Option<HexColor>, gnomex_domain::DomainError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(HexColor::new(trimmed)?))
     }
 }
 

--- a/data/io.github.gnomex.GnomeX.gschema.xml
+++ b/data/io.github.gnomex.GnomeX.gschema.xml
@@ -124,6 +124,39 @@
       <default>true</default>
       <summary>Show combo button inset border</summary>
     </key>
+    <key name="tb-color-button-bg-light" type="s">
+      <default>""</default>
+      <summary>Button background override (light)</summary>
+      <description>Per-scheme override for @button_bg_color under light colour scheme. Empty = no override.</description>
+    </key>
+    <key name="tb-color-button-bg-dark" type="s">
+      <default>""</default>
+      <summary>Button background override (dark)</summary>
+    </key>
+    <key name="tb-color-entry-bg-light" type="s">
+      <default>""</default>
+      <summary>Entry background override (light)</summary>
+    </key>
+    <key name="tb-color-entry-bg-dark" type="s">
+      <default>""</default>
+      <summary>Entry background override (dark)</summary>
+    </key>
+    <key name="tb-color-headerbar-bg-light" type="s">
+      <default>""</default>
+      <summary>Headerbar background override (light)</summary>
+    </key>
+    <key name="tb-color-headerbar-bg-dark" type="s">
+      <default>""</default>
+      <summary>Headerbar background override (dark)</summary>
+    </key>
+    <key name="tb-color-sidebar-bg-light" type="s">
+      <default>""</default>
+      <summary>Sidebar background override (light)</summary>
+    </key>
+    <key name="tb-color-sidebar-bg-dark" type="s">
+      <default>""</default>
+      <summary>Sidebar background override (dark)</summary>
+    </key>
     <key name="tb-widget-input-inset" type="d">
       <default>0.0</default>
       <summary>Input-field inset intensity</summary>


### PR DESCRIPTION
## Summary

Eight independent, optional colour overrides — four widgets × two schemes:

- **Button Background** (light / dark)
- **Input Background** (light / dark)
- **Headerbar Background** (light / dark)
- **Sidebar Background** (light / dark)

Each override maps to a Libadwaita `@define-color` token (`button_bg_color`, `entry_bg_color`, `headerbar_bg_color`, `sidebar_bg_color`) inside the appropriate `@media (prefers-color-scheme: ...)` block.

## Why

Tracker asked for "colors for specific widget types independently for both light and dark mode" — the flagship ask behind this issue. The existing accent-tint pipeline shares one colour across every surface; this gives users targeted escape hatches when they want a warm-toned button under a cool-toned desktop, or different button tones in light vs. dark mode.

## Ordering matters

`@define-color` in Libadwaita is **last-wins**. The overrides therefore land *after* `gtk_tint_css` in every version adapter. If a future refactor reorders those helpers, a user setting `sidebar_bg_light = #ffaa22` would silently get the accent-tinted default back. A test in `widget_color_overrides.rs` pins the ordering.

## UI trade-off

Eight colour pickers in a flat group would be loud. Opted for four rows (one per widget) each with two side-by-side colour buttons + a clear-both reset. Stays within Adwaita's row conventions and compresses to the same vertical space as the existing Sidebar group.

## Test plan

- [x] `cargo test --workspace` passes.
- [x] `cargo test --test widget_color_overrides` — 4/4 pass, including the ordering pin.
- [x] `glib-compile-schemas --strict --dry-run data/` validates the 8 new keys.
- [x] `cargo build -p gnomex-ui` compiles the new PreferencesGroup + message enum.
- [x] Manually verify: set button-bg-light = `#ffaa22`, confirm buttons turn orange under light scheme and stay default under dark. Set button-bg-dark = `#2244ff`, confirm dark scheme shows blue.
- [x] Manually verify: clear-both button on Headerbar row restores the accent-tinted default.

Closes #15