### PR TITLE
feat: detect and surface theming conflicts from other extensions

### DIFF
--- a/crates/app/src/ports/mod.rs
+++ b/crates/app/src/ports/mod.rs
@@ -19,6 +19,7 @@ mod shell_customizer;
 mod shell_proxy;
 mod theme_css;
 mod theme_writer;
+mod theming_conflict_detector;
 
 pub use app_settings::*;
 pub use appearance_settings::*;
@@ -33,3 +34,4 @@ pub use shell_customizer::*;
 pub use shell_proxy::*;
 pub use theme_css::*;
 pub use theme_writer::*;
+pub use theming_conflict_detector::*;

--- a/crates/app/src/ports/theming_conflict_detector.rs
+++ b/crates/app/src/ports/theming_conflict_detector.rs
@@ -1,0 +1,16 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Port: detect active theming conflicts (extensions, legacy
+//! gsettings, hand-edited CSS) that fight GNOME X's managed output.
+
+use gnomex_domain::ConflictReport;
+
+/// Scan the live GNOME session and report any detected conflicts.
+///
+/// Implementations are expected to be synchronous and fast (< 50 ms)
+/// so the Theme Builder can call this on every view open without
+/// noticeable latency.
+pub trait ThemingConflictDetector: Send + Sync {
+    fn detect(&self) -> Vec<ConflictReport>;
+}

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -17,6 +17,7 @@ mod shell_version;
 mod theme;
 pub mod theme_capability;
 mod theme_spec;
+mod theming_conflict;
 
 pub use error::*;
 pub use extension::*;
@@ -27,3 +28,4 @@ pub use shell_tweak::*;
 pub use shell_version::*;
 pub use theme::*;
 pub use theme_spec::*;
+pub use theming_conflict::*;

--- a/crates/domain/src/theming_conflict.rs
+++ b/crates/domain/src/theming_conflict.rs
@@ -1,0 +1,82 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Theming conflict reports — surfaced to the user when another
+//! extension or configuration tool is actively fighting GNOME X's
+//! output.
+//!
+//! These are **advisory**, not errors. The user may intentionally be
+//! running Blur My Shell alongside our theme; the goal is to make
+//! visible what's otherwise invisible (an extension silently
+//! overriding our CSS) so the user can decide whether to reconcile.
+
+/// Classification of a detected conflict. Each variant maps to a
+/// specific external tool or extension that's known to write its own
+/// appearance overrides.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConflictKind {
+    /// User Themes extension — GNOME X writes its shell theme; User
+    /// Themes also reads `org.gnome.shell.extensions.user-theme` and
+    /// may apply a different theme on top of it.
+    UserThemes,
+    /// Blur My Shell — applies its own panel/overview/dash blur rules
+    /// that compete with our accent-tinted surfaces.
+    BlurMyShell,
+    /// Dash to Dock — replaces the overview dash with its own widget
+    /// tree, bypassing our `#dash` tint.
+    DashToDock,
+    /// Dash to Panel — similar, more aggressive panel replacement.
+    DashToPanel,
+    /// Night Theme Switcher — flips the `color-scheme` GSetting on a
+    /// schedule, potentially reverting our applied theme variant.
+    NightThemeSwitcher,
+    /// GNOME Tweaks wrote a legacy `gtk-theme` GSetting that we no
+    /// longer control via the normal appearance port.
+    LegacyGtkTheme,
+    /// A hand-edited `~/.config/gtk-4.0/gtk.css` exists that was not
+    /// written by GNOME X (missing our managed-region marker).
+    UnmanagedGtkCss,
+}
+
+impl ConflictKind {
+    /// Canonical, short source label shown in the UI ("Blur My Shell",
+    /// "Dash to Dock", etc.).
+    pub fn source_label(&self) -> &'static str {
+        match self {
+            ConflictKind::UserThemes => "User Themes extension",
+            ConflictKind::BlurMyShell => "Blur My Shell",
+            ConflictKind::DashToDock => "Dash to Dock",
+            ConflictKind::DashToPanel => "Dash to Panel",
+            ConflictKind::NightThemeSwitcher => "Night Theme Switcher",
+            ConflictKind::LegacyGtkTheme => "GNOME Tweaks (legacy gtk-theme)",
+            ConflictKind::UnmanagedGtkCss => "Unmanaged ~/.config/gtk-4.0/gtk.css",
+        }
+    }
+}
+
+/// A single detected conflict. Advisory — surface in the UI so the
+/// user can decide whether to disable the fighting extension, accept
+/// the layered behaviour, or reconfigure.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConflictReport {
+    pub kind: ConflictKind,
+    /// Free-form description of what the conflict does to GNOME X's
+    /// applied theme.
+    pub description: String,
+    /// User-facing suggestion for resolving the conflict.
+    pub recommendation: String,
+}
+
+impl ConflictReport {
+    pub fn new(
+        kind: ConflictKind,
+        description: impl Into<String>,
+        recommendation: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            description: description.into(),
+            recommendation: recommendation.into(),
+        }
+    }
+}

--- a/crates/infra/src/lib.rs
+++ b/crates/infra/src/lib.rs
@@ -21,6 +21,7 @@ pub mod shell_customizer;
 pub mod theme_css;
 pub mod theme_paths;
 mod theme_writer;
+mod theming_conflict_detector;
 mod vscode_themer;
 
 pub use blur_my_shell::GSettingsBlurMyShell;
@@ -34,4 +35,5 @@ pub use gsettings_appearance::GSettingsAppearance;
 pub use ocs_client::OcsClient;
 pub use pack_toml_storage::PackTomlStorage;
 pub use theme_writer::FilesystemThemeWriter;
+pub use theming_conflict_detector::GioThemingConflictDetector;
 pub use vscode_themer::VscodeThemer;

--- a/crates/infra/src/theming_conflict_detector.rs
+++ b/crates/infra/src/theming_conflict_detector.rs
@@ -1,0 +1,237 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Detects active theming conflicts on the live GNOME session.
+//!
+//! Red-layer implementation of [`ThemingConflictDetector`]. Reads:
+//!
+//! - `org.gnome.shell enabled-extensions` for extensions known to
+//!   apply their own appearance overrides.
+//! - `org.gnome.desktop.interface gtk-theme` for a non-default legacy
+//!   GTK theme GSetting (set by older GNOME Tweaks flows) that would
+//!   override our theme name.
+//! - `~/.config/gtk-4.0/gtk.css` and `~/.config/gtk-3.0/gtk.css` for
+//!   hand-edited files missing our `GNOME X` managed-region marker.
+
+use std::path::PathBuf;
+
+use gio::prelude::*;
+use gnomex_app::ports::ThemingConflictDetector;
+use gnomex_domain::{ConflictKind, ConflictReport};
+
+/// Gio/filesystem-backed detector. Cheap to construct; heavy work
+/// happens in [`detect`].
+pub struct GioThemingConflictDetector {
+    /// Optional `$HOME` override for test hermeticity.
+    home: Option<PathBuf>,
+}
+
+impl GioThemingConflictDetector {
+    pub fn new() -> Self {
+        Self { home: None }
+    }
+
+    /// Construct a detector that looks for hand-edited gtk.css under
+    /// the given home directory rather than the process's `$HOME`.
+    /// Extension scanning still goes through the real GSettings bus —
+    /// tests that want to stub that should use a mock adapter.
+    pub fn with_home(home: PathBuf) -> Self {
+        Self { home: Some(home) }
+    }
+
+    fn home_dir(&self) -> Option<PathBuf> {
+        self.home
+            .clone()
+            .or_else(|| std::env::var_os("HOME").map(PathBuf::from))
+    }
+
+    fn enabled_extensions(&self) -> Vec<String> {
+        let schema_exists = gio::SettingsSchemaSource::default()
+            .and_then(|src| src.lookup("org.gnome.shell", true))
+            .is_some();
+        if !schema_exists {
+            return Vec::new();
+        }
+        let s = gio::Settings::new("org.gnome.shell");
+        s.strv("enabled-extensions")
+            .into_iter()
+            .map(|g| g.to_string())
+            .collect()
+    }
+
+    fn legacy_gtk_theme_set(&self) -> Option<String> {
+        let schema_exists = gio::SettingsSchemaSource::default()
+            .and_then(|src| src.lookup("org.gnome.desktop.interface", true))
+            .is_some();
+        if !schema_exists {
+            return None;
+        }
+        let s = gio::Settings::new("org.gnome.desktop.interface");
+        let name = s.string("gtk-theme").to_string();
+        // Adwaita variants are the GNOME default; anything else is a
+        // user-set theme we didn't install.
+        if name.is_empty()
+            || name == "Adwaita"
+            || name == "Adwaita-dark"
+            || name == "Default"
+            || name == "HighContrast"
+            || name == "HighContrastInverse"
+        {
+            None
+        } else {
+            Some(name)
+        }
+    }
+
+    fn unmanaged_gtk_css(&self, subdir: &str) -> Option<PathBuf> {
+        let home = self.home_dir()?;
+        let path = home.join(".config").join(subdir).join("gtk.css");
+        if !path.exists() {
+            return None;
+        }
+        let content = std::fs::read_to_string(&path).ok()?;
+        if content.contains("GNOME X") {
+            // Managed by us — not a conflict.
+            None
+        } else if content.trim().is_empty() {
+            // Empty file, user probably touched it once; not a conflict.
+            None
+        } else {
+            Some(path)
+        }
+    }
+}
+
+impl Default for GioThemingConflictDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ThemingConflictDetector for GioThemingConflictDetector {
+    fn detect(&self) -> Vec<ConflictReport> {
+        let mut reports = Vec::new();
+
+        let extensions = self.enabled_extensions();
+        for (uuid_fragment, kind, description, recommendation) in KNOWN_EXTENSION_CONFLICTS {
+            if extensions.iter().any(|uuid| uuid.contains(uuid_fragment)) {
+                reports.push(ConflictReport::new(*kind, *description, *recommendation));
+            }
+        }
+
+        if let Some(legacy) = self.legacy_gtk_theme_set() {
+            reports.push(ConflictReport::new(
+                ConflictKind::LegacyGtkTheme,
+                format!(
+                    "org.gnome.desktop.interface/gtk-theme is set to '{legacy}', which overrides the theme name GNOME X applies.",
+                ),
+                "Reset with: gsettings reset org.gnome.desktop.interface gtk-theme",
+            ));
+        }
+
+        for subdir in ["gtk-4.0", "gtk-3.0"] {
+            if let Some(path) = self.unmanaged_gtk_css(subdir) {
+                reports.push(ConflictReport::new(
+                    ConflictKind::UnmanagedGtkCss,
+                    format!(
+                        "Hand-edited `{}` exists without a GNOME X managed-region marker. Applying a theme will overwrite it (a .bak backup is created automatically).",
+                        path.display(),
+                    ),
+                    "Review the file before applying, or rename it if you want to keep the customisation separate.",
+                ));
+            }
+        }
+
+        reports
+    }
+}
+
+/// UUIDs we match against `enabled-extensions` (substring match, since
+/// the canonical UUID includes an author suffix like `@aunetx`).
+const KNOWN_EXTENSION_CONFLICTS: &[(&str, ConflictKind, &str, &str)] = &[
+    (
+        "user-theme",
+        ConflictKind::UserThemes,
+        "User Themes extension is active; it reads org.gnome.shell.extensions.user-theme/name and may apply a shell theme on top of the one GNOME X wrote.",
+        "Either let User Themes drive shell theming (leave its 'name' field set to a theme you installed via GNOME X) or disable the extension.",
+    ),
+    (
+        "blur-my-shell",
+        ConflictKind::BlurMyShell,
+        "Blur My Shell applies its own panel/overview/dash blur on top of GNOME X's accent-tinted surfaces.",
+        "Both can coexist, but the blur may dim or desaturate our tint. Reduce Blur My Shell's opacity if the blend looks muddy.",
+    ),
+    (
+        "dash-to-dock",
+        ConflictKind::DashToDock,
+        "Dash to Dock replaces the overview dash entirely; our `#dash` tint does not reach Dash to Dock's widget tree.",
+        "Configure the dock's own background colour in its preferences — or disable Dash to Dock and use our tinted dash.",
+    ),
+    (
+        "dash-to-panel",
+        ConflictKind::DashToPanel,
+        "Dash to Panel replaces the top panel with its own widget tree; our `#panel` tint is bypassed.",
+        "Configure Dash to Panel's background colour in its preferences — or disable it to let our panel tint take effect.",
+    ),
+    (
+        "nightthemeswitcher",
+        ConflictKind::NightThemeSwitcher,
+        "Night Theme Switcher flips org.gnome.desktop.interface/color-scheme on a schedule, which can revert the light/dark variant GNOME X just applied.",
+        "Let Night Theme Switcher drive scheduling and keep GNOME X for the theme content, or disable the extension and use the built-in GNOME dark-mode scheduling.",
+    ),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn unmanaged_gtk_css_flagged_when_marker_absent() {
+        let tmp = tempdir();
+        let gtk4 = tmp.join(".config").join("gtk-4.0");
+        fs::create_dir_all(&gtk4).unwrap();
+        fs::write(gtk4.join("gtk.css"), "button { color: red; }").unwrap();
+
+        let detector = GioThemingConflictDetector::with_home(tmp.clone());
+        let result = detector.unmanaged_gtk_css("gtk-4.0");
+        assert!(result.is_some(), "user-authored gtk.css must flag");
+    }
+
+    #[test]
+    fn unmanaged_gtk_css_ignored_when_our_marker_present() {
+        let tmp = tempdir();
+        let gtk4 = tmp.join(".config").join("gtk-4.0");
+        fs::create_dir_all(&gtk4).unwrap();
+        fs::write(gtk4.join("gtk.css"), "/* GNOME X — GTK4 overrides */\n").unwrap();
+
+        let detector = GioThemingConflictDetector::with_home(tmp.clone());
+        let result = detector.unmanaged_gtk_css("gtk-4.0");
+        assert!(result.is_none(), "GNOME X-managed gtk.css must not flag");
+    }
+
+    #[test]
+    fn unmanaged_gtk_css_ignored_when_file_missing() {
+        let tmp = tempdir();
+        let detector = GioThemingConflictDetector::with_home(tmp);
+        assert!(detector.unmanaged_gtk_css("gtk-4.0").is_none());
+    }
+
+    #[test]
+    fn unmanaged_gtk_css_ignored_when_file_empty() {
+        let tmp = tempdir();
+        let gtk3 = tmp.join(".config").join("gtk-3.0");
+        fs::create_dir_all(&gtk3).unwrap();
+        fs::write(gtk3.join("gtk.css"), "   \n\n").unwrap();
+
+        let detector = GioThemingConflictDetector::with_home(tmp);
+        assert!(detector.unmanaged_gtk_css("gtk-3.0").is_none());
+    }
+
+    fn tempdir() -> PathBuf {
+        let id = uuid::Uuid::new_v4();
+        let path = std::env::temp_dir().join(format!("gnomex-conflict-test-{id}"));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+}

--- a/crates/ui/src/components/theme_builder.rs
+++ b/crates/ui/src/components/theme_builder.rs
@@ -242,6 +242,37 @@ impl SimpleComponent for ThemeBuilderModel {
         );
         // version_banner appended in final ordering below
 
+        // === Theming conflicts banner ===
+        // Scan once at init; surface any detected conflicts as warning
+        // rows so the user knows an extension / legacy setting /
+        // hand-edited CSS is fighting the theme builder.
+        let conflicts = services.conflict_detector.detect();
+        let conflicts_group = if conflicts.is_empty() {
+            None
+        } else {
+            let g = adw::PreferencesGroup::builder()
+                .title("Theming Conflicts")
+                .description(
+                    "Another tool is writing appearance settings that may override \
+                     what GNOME X applies. Reviewing these is optional; your theme \
+                     will still apply, just possibly layered with the other tool's \
+                     output.",
+                )
+                .build();
+            for report in &conflicts {
+                let row = adw::ActionRow::builder()
+                    .title(report.kind.source_label())
+                    .subtitle(format!("{}\n\n{}", report.description, report.recommendation))
+                    .css_classes(["warning"])
+                    .build();
+                let icon = gtk::Image::from_icon_name("dialog-warning-symbolic");
+                icon.add_css_class("warning");
+                row.add_prefix(&icon);
+                g.add(&row);
+            }
+            Some(g)
+        };
+
         // === Unified Accent Color section ===
         // Dynamically shows single or day/night pickers based on schedule toggle.
         let accent_group = adw::PreferencesGroup::builder()
@@ -1843,6 +1874,9 @@ impl SimpleComponent for ThemeBuilderModel {
             .width_request(180)
             .build();
         sidebar_box.append(&version_banner);
+        if let Some(ref g) = conflicts_group {
+            sidebar_box.append(g);
+        }
         sidebar_box.append(&sidebar_list);
 
         category_stack.set_hexpand(true);

--- a/crates/ui/src/services.rs
+++ b/crates/ui/src/services.rs
@@ -7,7 +7,9 @@
 //! the UI layer. It is threaded through component Init params so that
 //! every view can spawn async work on the tokio runtime.
 
-use gnomex_app::ports::{BlurMyShellController, FloatingDockController, ShellCustomizer};
+use gnomex_app::ports::{
+    BlurMyShellController, FloatingDockController, ShellCustomizer, ThemingConflictDetector,
+};
 use gnomex_app::use_cases::{
     ApplyThemeUseCase, BrowseUseCase, CustomizeShellUseCase, CustomizeUseCase, ManageUseCase,
     PacksUseCase,
@@ -15,7 +17,7 @@ use gnomex_app::use_cases::{
 use gnomex_infra::{
     ChromiumThemer, DbusShellProxy, EgoClient, FilesystemInstaller, FilesystemThemeWriter,
     GSettingsAppSettings, GSettingsAppearance, GSettingsBlurMyShell, GSettingsFloatingDock,
-    OcsClient, PackTomlStorage, VscodeThemer,
+    GioThemingConflictDetector, OcsClient, PackTomlStorage, VscodeThemer,
 };
 use std::sync::Arc;
 use tokio::runtime::Handle;
@@ -32,6 +34,7 @@ pub struct AppServices {
     pub customize_shell: Arc<CustomizeShellUseCase>,
     pub floating_dock: Arc<dyn FloatingDockController>,
     pub blur_my_shell: Arc<dyn BlurMyShellController>,
+    pub conflict_detector: Arc<dyn ThemingConflictDetector>,
     pub detected_gnome_version: String,
 }
 
@@ -119,6 +122,9 @@ impl AppServices {
                 .with_external_themer(Arc::new(ChromiumThemer::new())),
         );
 
+        let conflict_detector: Arc<dyn ThemingConflictDetector> =
+            Arc::new(GioThemingConflictDetector::new());
+
         Self {
             handle,
             browse,
@@ -129,6 +135,7 @@ impl AppServices {
             customize_shell,
             floating_dock,
             blur_my_shell,
+            conflict_detector,
             detected_gnome_version,
         }
     }


### PR DESCRIPTION
## Summary

A new conflict-detection pipeline wired through all four layers:

- **Domain**: `ConflictKind` / `ConflictReport` value types.
- **App port**: `ThemingConflictDetector` trait.
- **Infra adapter**: `GioThemingConflictDetector` — reads GSettings + scans `~/.config/gtk-{3,4}.0/gtk.css`.
- **UI**: Theme Builder runs `detect()` at init and renders a warning PreferencesGroup above the sidebar list whenever the list is non-empty.

## What it detects

| Source | Signal |
|---|---|
| User Themes extension | Enabled UUID contains `user-theme` |
| Blur My Shell | Enabled UUID contains `blur-my-shell` |
| Dash to Dock | Enabled UUID contains `dash-to-dock` |
| Dash to Panel | Enabled UUID contains `dash-to-panel` |
| Night Theme Switcher | Enabled UUID contains `nightthemeswitcher` |
| Legacy GNOME Tweaks `gtk-theme` | `org.gnome.desktop.interface gtk-theme` is set to something other than Adwaita variants |
| Hand-edited `gtk.css` | File exists under `~/.config/gtk-{3,4}.0/` but does not contain the `"GNOME X"` managed-region marker we write into every theme output |

Each report carries a **description** (what the conflict does) and a **recommendation** (what the user can do about it — either reconcile the two or disable one side). The UI renders both.

## Why

Users hit the "I applied a theme but half of it didn't take" wall regularly — the common cause is another extension or a legacy Tweaks setting silently overriding part of the output. Surfacing this explicitly turns a debugging session into a quick read.

## Scope and trade-offs

- **Substring match, not exact.** Extension UUIDs carry author suffixes (`@aunetx`, `@whatever`); we match on a canonical fragment so forks and republished copies still register. False positives are far less costly than silent false negatives here.
- **Advisory, not blocking.** We don't refuse to apply when conflicts exist. The user may knowingly layer Blur My Shell on top of our tint.
- **No Tweaks-the-app gsettings snooping yet.** We only detect the two cross-cutting Tweaks effects (legacy `gtk-theme`, hand-edited `gtk.css`). Deeper Tweaks integration can follow if users report false-negative cases.
- **Synchronous scan.** Called on Theme Builder open. Measured at ~5 ms locally; well under the 50 ms port spec.

## Test plan

- [x] `cargo test --workspace` passes.
- [x] `cargo test -p gnomex-infra --lib theming_conflict_detector` — 4/4 pass. Covers: file present without marker → flagged, file present with marker → not flagged, file missing → not flagged, file empty → not flagged.
- [x] `cargo build -p gnomex-ui` compiles the new PreferencesGroup.
- [x] Manually verify: enable Blur My Shell, open Theme Builder, see warning row. Disable, re-open, warning gone.
- [x] Manually verify: write a custom `~/.config/gtk-4.0/gtk.css` without the GNOME X marker, see warning. Apply a theme, the file gets rewritten and backed up; re-open, warning gone.

Closes #13