### PR TITLE
docs(site): link r/GNOME_eXperience subreddit

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,13 +40,20 @@ Before filing: skim
 
 ## Sharing an Experience Pack
 
-If you've built a desktop look you're proud of, share its pack:
+If you've built a desktop look you're proud of, share its pack on
+**[r/GNOME_eXperience](https://www.reddit.com/r/GNOME_eXperience/)** —
+that's the community hub for packs, screenshots, and general
+GNOME-X-customisation discussion. A good post includes:
 
-1. Snapshot it (Packs tab → **Snapshot current desktop**) — see
-   [Build a pack](tutorials/build-a-pack.md).
-2. Export to a `.gnomex-pack.tar.gz`.
-3. Open an issue with the **`pack` label** and attach the file.
-4. Include a screenshot — packs without screenshots get less attention.
+1. A screenshot of the desktop the pack produces.
+2. The exported `.gnomex-pack.tar.gz` (Reddit accepts files up to 20 MB;
+   packs are typically under 100 KB).
+3. A one-line description of the look you were going for.
+4. The list of required extensions from the pack detail view, so readers
+   can see if any of them are deal-breakers.
+
+If the pack exposes a *bug* in GNOME X rather than a look, file a GitHub
+issue instead so it ends up on the tracker.
 
 We don't yet have a curated pack gallery on the site; this is tracked, and
 contributions to its design are welcome.

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,16 @@ step.
 | Flatpak         | not supported (intentional)           |
 | Login screen (GDM) | tracked, not yet shipped           |
 
+## Community
+
+- **[r/GNOME_eXperience](https://www.reddit.com/r/GNOME_eXperience/)** — the
+  subreddit for sharing Experience Packs, screenshots of customised
+  desktops, and general discussion. The best place to post a pack you've
+  built for other people to find.
+- **[GitHub issues](https://github.com/leechristophermurray/gnome-x/issues)**
+  — bug reports, feature requests, and architecture discussion. Use this
+  for anything actionable; use the subreddit for anything conversational.
+
 ## Where to go next
 
 - New here? [Install GNOME X](install.md), then read [First run](first-run.md).

--- a/zensical.toml
+++ b/zensical.toml
@@ -96,6 +96,11 @@ icon = "fontawesome/brands/github"
 link = "https://github.com/leechristophermurray/gnome-x"
 name = "GNOME X on GitHub"
 
+[[project.extra.social]]
+icon = "fontawesome/brands/reddit"
+link = "https://www.reddit.com/r/GNOME_eXperience/"
+name = "r/GNOME_eXperience on Reddit"
+
 # ----------------------------------------------------------------------------
 # Markdown extensions
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds the newly-created **[r/GNOME_eXperience](https://www.reddit.com/r/GNOME_eXperience/)** subreddit to the documentation site in three places:

- A site-wide footer icon (via a second `[[project.extra.social]]` entry in `zensical.toml`).
- A new **Community** section on the home page explaining when to use the subreddit vs. the GitHub tracker.
- The canonical destination for sharing Experience Packs in `contributing.md`, replacing the earlier "open a GitHub issue with the `pack` label" path.

## Why

The subreddit was just spun up as the conversational hub for Experience Pack sharing, screenshots, and general customisation discussion. The GitHub issue tracker is the wrong shape for show-and-tell content, and burying the link in only one place would limit discovery.

## Test plan

- [x] Wait for the Documentation workflow to deploy on merge.
- [ ] Verify the Reddit icon appears in the footer of every page on https://leechristophermurray.github.io/gnome-x/.
- [ ] Verify the new **Community** section on the home page links to the subreddit.
- [ ] Verify the `Sharing an Experience Pack` section on the Contributing page now points to Reddit.