### PR TITLE
feat: emit GTK3-specific CSS instead of byte-identical GTK4 output

### DIFF
--- a/crates/app/src/ports/theme_css.rs
+++ b/crates/app/src/ports/theme_css.rs
@@ -5,8 +5,18 @@ use crate::AppError;
 use gnomex_domain::ThemeSpec;
 
 /// Output of CSS generation — one stylesheet per target.
+///
+/// GTK4 and GTK3 use different token namespaces and widget selectors
+/// (GTK4/Libadwaita: `@window_bg_color`, `.navigation-sidebar`, `.card`,
+/// `splitview` etc.; GTK3: `@theme_bg_color`, `@theme_base_color`,
+/// `.sidebar`, etc.). Emitting byte-identical CSS to both targets made
+/// the GTK3 override mostly a no-op and sometimes actively worse than
+/// vanilla Adwaita, so the two payloads are produced as separate
+/// stylesheets and written to `gtk-4.0/gtk.css` and `gtk-3.0/gtk.css`
+/// independently (GXF-001).
 pub struct ThemeCss {
     pub gtk_css: String,
+    pub gtk3_css: String,
     pub shell_css: String,
 }
 

--- a/crates/app/src/ports/theme_writer.rs
+++ b/crates/app/src/ports/theme_writer.rs
@@ -4,8 +4,18 @@
 use crate::AppError;
 
 /// Port: persist generated CSS to the filesystem and activate it.
+///
+/// GTK4 and GTK3 use different token namespaces (`@window_bg_color` vs
+/// `@theme_bg_color`), different selectors (`.navigation-sidebar` vs
+/// `.sidebar`), and different feature sets. The writer takes both
+/// payloads separately so each can be routed to the correct XDG path
+/// (`~/.config/gtk-4.0/gtk.css` and `~/.config/gtk-3.0/gtk.css`
+/// respectively) without the infra layer having to split them.
 pub trait ThemeWriter: Send + Sync {
-    fn write_gtk_css(&self, css: &str) -> Result<(), AppError>;
+    /// Persist the GTK4 override to `gtk-4.0/gtk.css` and the GTK3
+    /// override to `gtk-3.0/gtk.css`. Both must carry a `"GNOME X"`
+    /// managed-region marker so the conflict detector recognises them.
+    fn write_gtk_css(&self, gtk4_css: &str, gtk3_css: &str) -> Result<(), AppError>;
     fn write_shell_css(&self, css: &str, theme_name: &str) -> Result<(), AppError>;
     fn clear_overrides(&self) -> Result<(), AppError>;
 }

--- a/crates/app/src/testing.rs
+++ b/crates/app/src/testing.rs
@@ -116,6 +116,7 @@ impl ThemeCssGenerator for MockCssGenerator {
         *self.last_spec.lock().unwrap() = Some(spec.clone());
         Ok(ThemeCss {
             gtk_css: "/* mock gtk */".to_owned(),
+            gtk3_css: "/* mock gtk3 */".to_owned(),
             shell_css: "/* mock shell */".to_owned(),
         })
     }
@@ -132,6 +133,7 @@ impl ThemeCssGenerator for MockCssGenerator {
 pub struct MockThemeWriter {
     pub calls: Mutex<Vec<String>>,
     pub last_gtk_css: Mutex<Option<String>>,
+    pub last_gtk3_css: Mutex<Option<String>>,
     pub last_shell_css: Mutex<Option<(String, String)>>,
 }
 
@@ -142,9 +144,10 @@ impl MockThemeWriter {
 }
 
 impl ThemeWriter for MockThemeWriter {
-    fn write_gtk_css(&self, css: &str) -> Result<(), AppError> {
+    fn write_gtk_css(&self, gtk4_css: &str, gtk3_css: &str) -> Result<(), AppError> {
         self.calls.lock().unwrap().push("write_gtk_css".into());
-        *self.last_gtk_css.lock().unwrap() = Some(css.to_owned());
+        *self.last_gtk_css.lock().unwrap() = Some(gtk4_css.to_owned());
+        *self.last_gtk3_css.lock().unwrap() = Some(gtk3_css.to_owned());
         Ok(())
     }
     fn write_shell_css(&self, css: &str, theme_name: &str) -> Result<(), AppError> {

--- a/crates/app/src/use_cases/apply_theme.rs
+++ b/crates/app/src/use_cases/apply_theme.rs
@@ -46,7 +46,7 @@ impl ApplyThemeUseCase {
     /// every registered external-app themer with a projection of `spec`.
     pub fn apply(&self, spec: &ThemeSpec) -> Result<(), AppError> {
         let css = self.gen_mock.generate(spec)?;
-        self.writer.write_gtk_css(&css.gtk_css)?;
+        self.writer.write_gtk_css(&css.gtk_css, &css.gtk3_css)?;
         self.writer.write_shell_css(&css.shell_css, CUSTOM_THEME_NAME)?;
         self.appearance.set_shell_theme(CUSTOM_THEME_NAME).ok();
 

--- a/crates/infra/src/theme_css/gnome45.rs
+++ b/crates/infra/src/theme_css/gnome45.rs
@@ -8,6 +8,7 @@ use super::common::{
     gtk_color_overrides_css, gtk_csd_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
     gtk_widget_color_overrides_css, gtk_widget_style_css, tint_shell_surfaces,
 };
+use super::gtk3::generate_gtk3_css;
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
 use gnomex_domain::ThemeSpec;
@@ -22,6 +23,7 @@ impl ThemeCssGenerator for Gnome45CssGenerator {
     fn generate(&self, spec: &ThemeSpec) -> Result<ThemeCss, AppError> {
         Ok(ThemeCss {
             gtk_css: self.gtk(spec),
+            gtk3_css: generate_gtk3_css(spec),
             shell_css: self.shell(spec),
         })
     }

--- a/crates/infra/src/theme_css/gnome46.rs
+++ b/crates/infra/src/theme_css/gnome46.rs
@@ -8,6 +8,7 @@ use super::common::{
     gtk_color_overrides_css, gtk_csd_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
     gtk_widget_color_overrides_css, gtk_widget_style_css, tint_shell_surfaces,
 };
+use super::gtk3::generate_gtk3_css;
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
 use gnomex_domain::ThemeSpec;
@@ -22,6 +23,7 @@ impl ThemeCssGenerator for Gnome46CssGenerator {
     fn generate(&self, spec: &ThemeSpec) -> Result<ThemeCss, AppError> {
         Ok(ThemeCss {
             gtk_css: self.gtk(spec),
+            gtk3_css: generate_gtk3_css(spec),
             shell_css: self.shell(spec),
         })
     }

--- a/crates/infra/src/theme_css/gnome47.rs
+++ b/crates/infra/src/theme_css/gnome47.rs
@@ -10,6 +10,7 @@ use super::common::{
     gtk_widget_color_overrides_css, gtk_widget_style_css, shell_notification_css,
     tint_shell_surfaces,
 };
+use super::gtk3::generate_gtk3_css;
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
 use gnomex_domain::ThemeSpec;
@@ -24,6 +25,7 @@ impl ThemeCssGenerator for Gnome47CssGenerator {
     fn generate(&self, spec: &ThemeSpec) -> Result<ThemeCss, AppError> {
         Ok(ThemeCss {
             gtk_css: self.gtk(spec),
+            gtk3_css: generate_gtk3_css(spec),
             shell_css: self.shell(spec),
         })
     }

--- a/crates/infra/src/theme_css/gnome50.rs
+++ b/crates/infra/src/theme_css/gnome50.rs
@@ -13,6 +13,7 @@ use super::common::{
     gtk_color_overrides_css, gtk_csd_css, gtk_layer_separation_css, gtk_radius_css, gtk_tint_css,
     gtk_widget_color_overrides_css, gtk_widget_style_css,
 };
+use super::gtk3::generate_gtk3_css;
 use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
 use gnomex_app::AppError;
 use gnomex_domain::ThemeSpec;
@@ -35,6 +36,7 @@ impl ThemeCssGenerator for Gnome50CssGenerator {
     fn generate(&self, spec: &ThemeSpec) -> Result<ThemeCss, AppError> {
         Ok(ThemeCss {
             gtk_css: self.gtk(spec),
+            gtk3_css: generate_gtk3_css(spec),
             shell_css: self.shell(spec),
         })
     }

--- a/crates/infra/src/theme_css/gtk3.rs
+++ b/crates/infra/src/theme_css/gtk3.rs
@@ -1,0 +1,572 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! GTK3 CSS generator (GXF-001).
+//!
+//! GTK3's token namespace and widget tree diverge meaningfully from
+//! GTK4/Libadwaita. Previously the theme writer emitted byte-identical
+//! CSS to both `gtk-4.0/gtk.css` and `gtk-3.0/gtk.css`, which made the
+//! GTK3 override a mostly-no-op and sometimes actively worse than
+//! vanilla Adwaita (GTK3 would see a pile of undefined `@window_bg_color`
+//! / `@card_bg_color` references and GTK4-only selectors like
+//! `.navigation-sidebar`, `.card`, `splitview`, `popover > contents`).
+//!
+//! GTK 3.24 is the last stable GTK3 release line; GNOME X targets only
+//! that — there is no need for per-GNOME-version variants the way
+//! Adwaita has. A single generator covers every Flatpak'd Chromium,
+//! Electron app, and legacy GNOME utility that still renders under GTK3.
+//!
+//! ## ThemeSpec knob translation
+//!
+//! | Knob                                     | GTK3 mapping                                                              |
+//! |------------------------------------------|---------------------------------------------------------------------------|
+//! | `tint.accent_hex` / `tint.intensity`     | `@theme_bg_color`, `@theme_base_color`, `@theme_selected_bg_color`        |
+//! | `window_radius` / `element_radius`       | `.titlebar`, `window`, `button`, `entry` `border-radius`                  |
+//! | `headerbar.min_height`                   | `headerbar`, `.titlebar` `min-height`                                     |
+//! | `headerbar.shadow_intensity`             | `headerbar` `box-shadow` inset                                            |
+//! | `headerbar.circular_buttons`             | `headerbar button.titlebutton` border-radius                              |
+//! | `window_frame.show_shadow`               | `window.csd` `box-shadow: none;` when disabled                            |
+//! | `window_frame.inset_border`              | `window.csd` inset `box-shadow` border                                    |
+//! | `insets.card_border_width`               | `frame.flat, frame, list.content` (GTK3 has no `.card`)                   |
+//! | `insets.separator_opacity`               | `separator` `opacity`                                                     |
+//! | `insets.focus_ring_width`                | `*:focus` `outline-width` (GTK3 uses `:focus`, not `:focus-visible`)      |
+//! | `widget_style.input_inset`               | `entry, spinbutton` (same selectors)                                      |
+//! | `widget_style.button_raise`              | `button:not(.flat)` (no `.suggested-action`/`.destructive-action` in GTK3)|
+//! | `widget_style.headerbar_gradient`        | `headerbar, .titlebar, .toolbar` `linear-gradient`                        |
+//! | `widget_colors.*`                        | `@theme_*` token overrides via `@define-color`                            |
+//! | `foreground.window_fg`                   | `@theme_fg_color`                                                         |
+//! | `foreground.view_fg`                     | `@theme_text_color`                                                       |
+//! | `foreground.headerbar_fg`                | `headerbar { color: ... }` (GTK3 has no dedicated token)                  |
+//! | `sidebar.fg_override`                    | `.sidebar, .nautilus-list-view .sidebar { color: ... }`                   |
+//! | `sidebar.opacity`                        | `.sidebar` background alpha                                               |
+//! | `layers.headerbar_bottom`                | `headerbar, .titlebar { border-bottom: ... }`                             |
+//! | `layers.sidebar_divider`                 | `.sidebar { border-right: ... }` (no `.navigation-sidebar`)               |
+//! | `layers.content_contrast`                | n/a — GTK3 lacks the `.content-pane`/`splitview` tree                     |
+//! | `status_colors.*`                        | `@error_color`, `@warning_color`, `@success_color` token overrides        |
+//! | `notifications.*`                        | n/a — GTK3 apps get shell-side notifications, not CSS-styled              |
+//! | `overview_blur`, `panel.*`, `dash.*`     | n/a — these are Shell-only                                                |
+//! | `headerbar_backdrop_color`, `card_bg_color`, `popover_bg_color` | n/a — GTK3 doesn't expose these tokens         |
+//!
+//! ### Dark variant handling
+//!
+//! GTK 3.24 does **not** support `@media (prefers-color-scheme: ...)`.
+//! The generator emits a single variant keyed to the panel-tint
+//! luminance (same heuristic the external themers use). If the user
+//! wants dark GTK3 apps they must also set
+//! `org.gnome.desktop.interface gtk-application-prefer-dark-theme`
+//! or install a dedicated GTK3 dark theme — that's a user-level
+//! setting, not something we write into `gtk-3.0/gtk.css`.
+
+use gnomex_app::ports::{ThemeCss, ThemeCssGenerator};
+use gnomex_app::AppError;
+use gnomex_domain::{color::blend, ColorScheme, HexColor, ThemeSpec};
+
+/// Header comment embedded in every GTK3 stylesheet we emit. Contains
+/// the literal `"GNOME X"` substring the conflict detector greps for.
+const GTK3_HEADER: &str = "/* GNOME X — GTK3 overrides */";
+
+/// CSS generator for GTK 3.24+.
+///
+/// Produces output targeting the `@theme_bg_color` / `@theme_base_color`
+/// token namespace and GTK3-only widget selectors. See the module
+/// docstring for the full `ThemeSpec` translation table.
+pub struct Gtk3CssGenerator;
+
+impl ThemeCssGenerator for Gtk3CssGenerator {
+    fn version_label(&self) -> &str {
+        "GTK 3.24+"
+    }
+
+    fn generate(&self, spec: &ThemeSpec) -> Result<ThemeCss, AppError> {
+        Ok(ThemeCss {
+            gtk_css: String::new(),
+            gtk3_css: generate_gtk3_css(spec),
+            shell_css: String::new(),
+        })
+    }
+}
+
+/// Build the full GTK3 stylesheet for `spec`.
+///
+/// Exposed as a free function so the per-GNOME-version generators can
+/// fill their `ThemeCss::gtk3_css` field without constructing a
+/// `Gtk3CssGenerator` + re-dispatching through the trait.
+pub fn generate_gtk3_css(spec: &ThemeSpec) -> String {
+    let scheme = scheme_from_panel_tint(&spec.panel.tint);
+    let mut out = String::new();
+    out.push_str(GTK3_HEADER);
+    out.push('\n');
+    out.push_str("/* Generated for GTK 3.24+ — @theme_* token namespace. */\n");
+    out.push_str("/* Single-variant output keyed to panel-tint luminance */\n");
+    out.push_str("/* (GTK3 has no colour-scheme media query). */\n\n");
+
+    out.push_str(&gtk3_tint_css(spec, scheme));
+    out.push('\n');
+    out.push_str(&gtk3_radius_css(spec));
+    out.push('\n');
+    out.push_str(&gtk3_csd_css(spec));
+    out.push('\n');
+    out.push_str(&gtk3_layer_separation_css(spec));
+    out.push_str(&gtk3_widget_style_css(spec));
+    out.push_str(&gtk3_foreground_css(spec));
+    out.push_str(&gtk3_sidebar_css(spec));
+    out.push_str(&gtk3_widget_color_overrides_css(spec));
+    out.push_str(&gtk3_status_colors_css(spec));
+
+    out
+}
+
+/// Derive a light/dark variant flag from the panel tint luminance.
+/// GTK3 has no native colour-scheme media query, so we pick one at
+/// generation time (same heuristic the external-app themers use).
+fn scheme_from_panel_tint(hex: &HexColor) -> ColorScheme {
+    let (r, g, b) = hex.to_rgb();
+    let luma = 0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32;
+    if luma < 128.0 {
+        ColorScheme::Dark
+    } else {
+        ColorScheme::Light
+    }
+}
+
+/// Emit the GTK3 accent-tint block against the legacy `@theme_*`
+/// namespace. Uses hex-blended bases rather than `mix(@accent_bg_color, ...)`
+/// because GTK3 does not expose `@accent_bg_color` (that's a
+/// Libadwaita-only named colour).
+fn gtk3_tint_css(spec: &ThemeSpec, scheme: ColorScheme) -> String {
+    let accent = spec.tint.accent_hex.to_rgb();
+    let pct = spec.tint.intensity.as_fraction() as f32;
+
+    let (window_base, view_base, headerbar_base, sidebar_base): (
+        (u8, u8, u8),
+        (u8, u8, u8),
+        (u8, u8, u8),
+        (u8, u8, u8),
+    ) = if scheme.is_dark() {
+        // GTK3 Adwaita-dark base palette.
+        (
+            (0x24, 0x24, 0x28),
+            (0x1d, 0x1d, 0x20),
+            (0x2e, 0x2e, 0x32),
+            (0x2a, 0x2a, 0x2e),
+        )
+    } else {
+        // GTK3 Adwaita light base palette.
+        (
+            (0xfa, 0xfa, 0xfb),
+            (0xff, 0xff, 0xff),
+            (0xeb, 0xeb, 0xed),
+            (0xf0, 0xf0, 0xf2),
+        )
+    };
+
+    let window_bg = blend(window_base, accent, pct);
+    let view_bg = blend(view_base, accent, pct);
+    let headerbar_bg = blend(headerbar_base, accent, pct);
+    let sidebar_bg = blend(sidebar_base, accent, pct);
+    let selected_bg = spec.tint.accent_hex.as_str();
+
+    format!(
+        r#"/* Accent-tinted surfaces */
+@define-color theme_bg_color {window_bg};
+@define-color theme_base_color {view_bg};
+@define-color theme_selected_bg_color {selected_bg};
+@define-color headerbar_bg_color {headerbar_bg};
+@define-color sidebar_bg_color {sidebar_bg};
+"#,
+    )
+}
+
+/// Border-radius rules against GTK3 selectors (`.titlebar` instead of
+/// `headerbar`-only, no `.card`, no `popover > contents`).
+fn gtk3_radius_css(spec: &ThemeSpec) -> String {
+    let wr = spec.window_radius.as_i32();
+    let er = spec.element_radius.as_i32();
+    format!(
+        r#"/* Border radius */
+window, window.background {{ border-radius: {wr}px; }}
+.titlebar, headerbar {{ border-radius: {wr}px {wr}px 0 0; }}
+button {{ border-radius: {er}px; }}
+entry, spinbutton {{ border-radius: {er}px; }}
+"#
+    )
+}
+
+/// Headerbar / CSD rules translated to GTK3.
+/// GTK3 uses `.titlebar` alongside `headerbar`, has no
+/// `:focus-visible` pseudo (uses `:focus` instead), and has no
+/// `.card` class. Combo-box insets use `GtkComboBox` not `.combo`.
+fn gtk3_csd_css(spec: &ThemeSpec) -> String {
+    let hb = &spec.headerbar;
+    let wf = &spec.window_frame;
+    let insets = &spec.insets;
+
+    let hb_height = hb.min_height.as_i32();
+    let hb_shadow = hb.shadow_intensity.as_fraction();
+
+    let titlebar_btn_css = if hb.circular_buttons {
+        "headerbar button.titlebutton, .titlebar button.titlebutton {\n\
+         \x20   border-radius: 50%;\n\
+         \x20   min-width: 14px;\n\
+         \x20   min-height: 14px;\n\
+         \x20   padding: 2px;\n\
+         }"
+    } else {
+        ""
+    };
+
+    let window_shadow = if wf.show_shadow {
+        ""
+    } else {
+        "window, window.csd, .window-frame {\n\
+         \x20   box-shadow: none;\n\
+         \x20   margin: 0;\n\
+         }"
+    };
+
+    let inset_border = wf.inset_border.as_i32();
+    let inset_css = if inset_border > 0 {
+        format!(
+            "window.csd {{ box-shadow: inset 0 0 0 {inset_border}px @borders; }}"
+        )
+    } else {
+        String::new()
+    };
+
+    // GTK3 has no `.card` — the nearest legacy analogue is `frame` /
+    // `list.content`, which sidebar-style groups use.
+    let card_border = insets.card_border_width.as_i32();
+    let sep_opacity = insets.separator_opacity.as_fraction();
+    let focus_width = insets.focus_ring_width.as_i32();
+
+    let combo_css = if !insets.combo_inset {
+        "combobox button, combobox entry { border: none; box-shadow: none; }"
+    } else {
+        ""
+    };
+
+    format!(
+        r#"/* Headerbar CSD */
+headerbar, .titlebar {{
+    min-height: {hb_height}px;
+    box-shadow: inset 0 -1px alpha(black, {hb_shadow});
+}}
+
+{titlebar_btn_css}
+
+{window_shadow}
+
+{inset_css}
+
+/* "Card"-like frames (GTK3 has no `.card` class) */
+frame.flat, list.content {{ border: {card_border}px solid @borders; }}
+
+/* Separator visibility */
+separator {{ opacity: {sep_opacity}; }}
+
+/* Focus ring (GTK3 uses :focus, not :focus-visible) */
+*:focus {{ outline-width: {focus_width}px; }}
+
+{combo_css}
+"#
+    )
+}
+
+/// Layer-separation translated to GTK3 selectors.
+/// `content_contrast` is intentionally dropped: GTK3 has no
+/// `.content-pane` / `splitview` widget tree, so there is nothing
+/// sensible to target that wouldn't re-tint every `.view`.
+fn gtk3_layer_separation_css(spec: &ThemeSpec) -> String {
+    let hb = spec.layers.headerbar_bottom.as_i32();
+    let sb = spec.layers.sidebar_divider.as_i32();
+
+    if hb == 0 && sb == 0 {
+        return String::new();
+    }
+
+    let mut out = String::from("/* Layer separation */\n");
+
+    if hb > 0 {
+        out.push_str(&format!(
+            "headerbar, .titlebar {{ border-bottom: {hb}px solid @borders; }}\n\
+             headerbar.flat, .titlebar.flat {{ border-bottom: {hb}px solid @borders; }}\n",
+        ));
+    }
+
+    if sb > 0 {
+        // GTK3 has no `.navigation-sidebar` — `.sidebar` is the common
+        // class used by Nautilus (GTK3 era), GIMP, etc.
+        out.push_str(&format!(
+            ".sidebar, .nautilus-list-view .sidebar {{ border-right: {sb}px solid @borders; }}\n",
+        ));
+    }
+
+    out
+}
+
+/// Restore-traditional-chrome knobs mapped to GTK3 selectors.
+/// Button :not() filter drops the Libadwaita-only classes
+/// `.suggested-action` / `.destructive-action` and keeps only the one
+/// GTK3 actually uses (`.flat`).
+fn gtk3_widget_style_css(spec: &ThemeSpec) -> String {
+    let input = spec.widget_style.input_inset.as_fraction();
+    let button = spec.widget_style.button_raise.as_fraction();
+    let gradient = spec.widget_style.headerbar_gradient.as_fraction();
+
+    if input <= f64::EPSILON && button <= f64::EPSILON && gradient <= f64::EPSILON {
+        return String::new();
+    }
+
+    let mut out = String::from("/* Widget style */\n");
+
+    if input > f64::EPSILON {
+        let border_alpha = 0.08 + 0.22 * input;
+        let inset_shadow = 0.10 * input;
+        out.push_str(&format!(
+            "entry, entry.flat, spinbutton, spinbutton.flat {{\n\
+             \x20   border: 1px solid alpha(currentColor, {border_alpha:.3});\n\
+             \x20   box-shadow: inset 0 1px 0 alpha(black, {inset_shadow:.3});\n\
+             }}\n",
+        ));
+    }
+
+    if button > f64::EPSILON {
+        let border_alpha = 0.10 + 0.25 * button;
+        let shadow_alpha = 0.08 + 0.15 * button;
+        out.push_str(&format!(
+            "button:not(.flat) {{\n\
+             \x20   border: 1px solid alpha(currentColor, {border_alpha:.3});\n\
+             \x20   box-shadow: 0 1px 0 alpha(black, {shadow_alpha:.3});\n\
+             }}\n\
+             button:not(.flat):active {{\n\
+             \x20   box-shadow: inset 0 1px 0 alpha(black, {shadow_alpha:.3});\n\
+             }}\n",
+        ));
+    }
+
+    if gradient > f64::EPSILON {
+        let delta = 0.03 + 0.06 * gradient;
+        out.push_str(&format!(
+            "headerbar, .titlebar, toolbar, .toolbar {{\n\
+             \x20   background-image: linear-gradient(to bottom,\n\
+             \x20       shade(@headerbar_bg_color, {top:.3}),\n\
+             \x20       shade(@headerbar_bg_color, {bot:.3}));\n\
+             }}\n",
+            top = 1.0 + delta,
+            bot = 1.0 - delta,
+        ));
+    }
+
+    out
+}
+
+/// Foreground overrides against the GTK3 `@theme_fg_color` /
+/// `@theme_text_color` tokens. `headerbar_fg` has no dedicated GTK3
+/// token so it is applied directly to the `headerbar` selector.
+fn gtk3_foreground_css(spec: &ThemeSpec) -> String {
+    let fg = &spec.foreground;
+    let mut out = String::new();
+    let mut body = String::new();
+
+    if let Some(c) = &fg.window_fg {
+        body.push_str(&format!(
+            "@define-color theme_fg_color {};\n",
+            c.as_str()
+        ));
+    }
+    if let Some(c) = &fg.view_fg {
+        body.push_str(&format!(
+            "@define-color theme_text_color {};\n",
+            c.as_str()
+        ));
+    }
+    if let Some(c) = &fg.headerbar_fg {
+        body.push_str(&format!(
+            "headerbar, .titlebar {{ color: {}; }}\n",
+            c.as_str()
+        ));
+    }
+    if let Some(c) = &fg.headerbar_border {
+        body.push_str(&format!(
+            "headerbar, .titlebar {{ border-color: {}; }}\n",
+            c.as_str()
+        ));
+    }
+
+    if !body.is_empty() {
+        out.push_str("/* Foreground overrides */\n");
+        out.push_str(&body);
+    }
+    out
+}
+
+/// Sidebar-specific rules translated to GTK3's `.sidebar` class
+/// (used by Nautilus-GTK3, GIMP, Inkscape-3, etc.) — **not**
+/// `.navigation-sidebar`, which is GTK4-only.
+fn gtk3_sidebar_css(spec: &ThemeSpec) -> String {
+    let opacity = spec.sidebar.opacity.as_fraction();
+    let mut out = String::new();
+    let mut body = String::new();
+
+    if opacity < 0.999 {
+        body.push_str(&format!(
+            ".sidebar, .nautilus-list-view .sidebar {{\n\
+             \x20   background-color: alpha(@sidebar_bg_color, {opacity:.3});\n\
+             }}\n",
+        ));
+    }
+
+    if let Some(c) = &spec.sidebar.fg_override {
+        body.push_str(&format!(
+            ".sidebar, .nautilus-list-view .sidebar {{ color: {}; }}\n",
+            c.as_str()
+        ));
+    }
+
+    if !body.is_empty() {
+        out.push_str("/* Sidebar */\n");
+        out.push_str(&body);
+    }
+    out
+}
+
+/// Per-widget colour overrides against the GTK3 token namespace.
+/// GTK3 has no `prefers-color-scheme` so `*_light` vs `*_dark` fields
+/// are combined — whichever variant matches the currently-chosen
+/// scheme wins. See `scheme_from_panel_tint`.
+fn gtk3_widget_color_overrides_css(spec: &ThemeSpec) -> String {
+    let w = &spec.widget_colors;
+    if w.is_empty() {
+        return String::new();
+    }
+
+    let scheme = scheme_from_panel_tint(&spec.panel.tint);
+    let is_dark = scheme.is_dark();
+
+    fn pick<'a>(
+        light: &'a Option<HexColor>,
+        dark: &'a Option<HexColor>,
+        is_dark: bool,
+    ) -> Option<&'a HexColor> {
+        if is_dark {
+            dark.as_ref().or(light.as_ref())
+        } else {
+            light.as_ref().or(dark.as_ref())
+        }
+    }
+
+    let button = pick(&w.button_bg_light, &w.button_bg_dark, is_dark);
+    let entry = pick(&w.entry_bg_light, &w.entry_bg_dark, is_dark);
+    let headerbar = pick(&w.headerbar_bg_light, &w.headerbar_bg_dark, is_dark);
+    let sidebar = pick(&w.sidebar_bg_light, &w.sidebar_bg_dark, is_dark);
+
+    let mut out = String::from("/* Per-widget colour overrides */\n");
+    if let Some(c) = button {
+        out.push_str(&format!(
+            "button:not(.flat) {{ background-color: {}; background-image: none; }}\n",
+            c.as_str()
+        ));
+    }
+    if let Some(c) = entry {
+        out.push_str(&format!(
+            "entry, spinbutton {{ background-color: {}; background-image: none; }}\n",
+            c.as_str()
+        ));
+    }
+    if let Some(c) = headerbar {
+        out.push_str(&format!(
+            "@define-color headerbar_bg_color {};\n",
+            c.as_str()
+        ));
+        out.push_str(&format!(
+            "headerbar, .titlebar {{ background-color: {}; background-image: none; }}\n",
+            c.as_str()
+        ));
+    }
+    if let Some(c) = sidebar {
+        out.push_str(&format!(
+            "@define-color sidebar_bg_color {};\n",
+            c.as_str()
+        ));
+        out.push_str(&format!(
+            ".sidebar {{ background-color: {}; }}\n",
+            c.as_str()
+        ));
+    }
+
+    out
+}
+
+/// Semantic status-colour overrides against the GTK3 `@error_color`,
+/// `@warning_color`, `@success_color` named-colour tokens.
+fn gtk3_status_colors_css(spec: &ThemeSpec) -> String {
+    let sc = &spec.status_colors;
+    let mut body = String::new();
+    if let Some(c) = &sc.destructive {
+        body.push_str(&format!(
+            "@define-color destructive_color {};\n",
+            c.as_str()
+        ));
+    }
+    if let Some(c) = &sc.success {
+        body.push_str(&format!("@define-color success_color {};\n", c.as_str()));
+    }
+    if let Some(c) = &sc.warning {
+        body.push_str(&format!("@define-color warning_color {};\n", c.as_str()));
+    }
+    if let Some(c) = &sc.error {
+        body.push_str(&format!("@define-color error_color {};\n", c.as_str()));
+    }
+    if body.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("/* Semantic status colors */\n");
+    out.push_str(&body);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gnomex_domain::ThemeSpec;
+
+    #[test]
+    fn default_spec_contains_gnome_x_marker() {
+        let css = generate_gtk3_css(&ThemeSpec::defaults());
+        assert!(
+            css.contains("GNOME X"),
+            "GTK3 output is missing the managed-region marker; conflict detector will false-positive every user:\n{css}"
+        );
+    }
+
+    #[test]
+    fn default_spec_emits_theme_bg_color_not_window_bg_color() {
+        let css = generate_gtk3_css(&ThemeSpec::defaults());
+        assert!(
+            css.contains("@define-color theme_bg_color"),
+            "GTK3 output missing `@theme_bg_color` — the legacy namespace is the only one GTK3 honours.\n{css}",
+        );
+        assert!(
+            !css.contains("@define-color window_bg_color"),
+            "GTK3 output contains GTK4-only `@window_bg_color`; should be `@theme_bg_color`.\n{css}",
+        );
+    }
+
+    #[test]
+    fn default_spec_does_not_emit_gtk4_only_selectors() {
+        // These selectors are GTK4/Libadwaita-only and cause GTK3 to
+        // log CSS-parser warnings at every widget instantiation.
+        let css = generate_gtk3_css(&ThemeSpec::defaults());
+        for selector in [".navigation-sidebar", ".card ", "splitview", "popover > contents"] {
+            assert!(
+                !css.contains(selector),
+                "GTK3 output leaked GTK4-only selector `{selector}`:\n{css}",
+            );
+        }
+    }
+
+    #[test]
+    fn version_label_is_gtk3() {
+        assert_eq!(Gtk3CssGenerator.version_label(), "GTK 3.24+");
+    }
+}

--- a/crates/infra/src/theme_css/mod.rs
+++ b/crates/infra/src/theme_css/mod.rs
@@ -6,12 +6,18 @@
 //! Each supported GNOME version has its own adapter implementing
 //! `ThemeCssGenerator`. The factory selects the right one at runtime
 //! based on the detected shell version.
+//!
+//! The GTK3 output does **not** depend on the GNOME version — GTK 3.24
+//! is the last stable release line — so a single [`gtk3::Gtk3CssGenerator`]
+//! covers every case and each per-version adapter fills `ThemeCss::gtk3_css`
+//! from the shared [`gtk3::generate_gtk3_css`] helper (GXF-001).
 
 mod common;
 mod gnome45;
 mod gnome46;
 mod gnome47;
 mod gnome50;
+pub mod gtk3;
 
 use gnomex_app::ports::ThemeCssGenerator;
 use gnomex_domain::ShellVersion;

--- a/crates/infra/src/theme_writer.rs
+++ b/crates/infra/src/theme_writer.rs
@@ -12,14 +12,18 @@ const CUSTOM_SHELL_THEME_NAME: &str = "GNOME-X-Custom";
 
 /// Concrete adapter: write theme CSS to the local filesystem.
 ///
-/// Writes both the GTK4 override (`gtk-4.0/gtk.css`, primary target)
-/// and the GTK3 override (`gtk-3.0/gtk.css`, for legacy and sandboxed
-/// Chromium/Electron apps that still render under GTK3) on every
-/// `write_gtk_css`. Both files are backed up once before the first
-/// overwrite so `clear_overrides` can restore the user's pre-GNOME-X
-/// state.
+/// Writes the GTK4 override (`gtk-4.0/gtk.css`, primary target) and a
+/// *separately-generated* GTK3 override (`gtk-3.0/gtk.css`, for legacy
+/// and sandboxed Chromium/Electron apps that still render under GTK3)
+/// on every `write_gtk_css`. The two payloads target different token
+/// namespaces (`@window_bg_color` vs `@theme_bg_color`) and different
+/// widget selectors (`.navigation-sidebar` vs `.sidebar`, etc.), so
+/// they are produced independently by the CSS generator (GXF-001).
+/// Both files are backed up once before the first overwrite so
+/// `clear_overrides` can restore the user's pre-GNOME-X state.
 ///
-/// Related tracker items: GXF-010 (multi-path resolution).
+/// Related tracker items: GXF-001 (GTK3 vs GTK4 divergence),
+/// GXF-010 (multi-path resolution).
 pub struct FilesystemThemeWriter {
     paths: ResourcePaths,
     shell_theme_dir: PathBuf,
@@ -41,14 +45,14 @@ impl FilesystemThemeWriter {
 }
 
 impl ThemeWriter for FilesystemThemeWriter {
-    fn write_gtk_css(&self, css: &str) -> Result<(), AppError> {
-        // Both GTK4 (primary) and GTK3 (for legacy / sandboxed apps
-        // that still render on the older toolkit) get the same CSS.
-        // Each path is independently backed up once.
+    fn write_gtk_css(&self, gtk4_css: &str, gtk3_css: &str) -> Result<(), AppError> {
+        // GTK4 gets the Libadwaita-flavoured payload; GTK3 gets a
+        // parallel payload built against the legacy `@theme_*` token
+        // namespace and GTK3 widget tree. Each path is independently
+        // backed up once.
         let targets = self.gtk_override_files();
-        for path in [&targets.gtk4, &targets.gtk3] {
-            write_gtk_override(path, css)?;
-        }
+        write_gtk_override(&targets.gtk4, gtk4_css)?;
+        write_gtk_override(&targets.gtk3, gtk3_css)?;
         Ok(())
     }
 
@@ -139,14 +143,37 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let writer = tmp_writer(dir.path());
 
-        writer.write_gtk_css("/* test */").unwrap();
+        writer.write_gtk_css("/* gtk4 */", "/* gtk3 */").unwrap();
 
         let gtk4 = dir.path().join(".config/gtk-4.0/gtk.css");
         let gtk3 = dir.path().join(".config/gtk-3.0/gtk.css");
         assert!(gtk4.exists(), "missing {}", gtk4.display());
         assert!(gtk3.exists(), "missing {}", gtk3.display());
-        assert_eq!(std::fs::read_to_string(&gtk4).unwrap(), "/* test */");
-        assert_eq!(std::fs::read_to_string(&gtk3).unwrap(), "/* test */");
+        assert_eq!(std::fs::read_to_string(&gtk4).unwrap(), "/* gtk4 */");
+        assert_eq!(std::fs::read_to_string(&gtk3).unwrap(), "/* gtk3 */");
+    }
+
+    #[test]
+    fn write_gtk_css_routes_payloads_to_correct_targets() {
+        // Pins the core invariant of this feature: GTK4 CSS must land
+        // at `gtk-4.0/gtk.css`, GTK3 CSS must land at `gtk-3.0/gtk.css`,
+        // and the two must never bleed into each other.
+        let dir = TempDir::new().unwrap();
+        let writer = tmp_writer(dir.path());
+
+        writer
+            .write_gtk_css(
+                "/* GNOME X — GTK4 overrides */\n@define-color window_bg_color #abc;",
+                "/* GNOME X — GTK3 overrides */\n@define-color theme_bg_color #def;",
+            )
+            .unwrap();
+
+        let gtk4 = std::fs::read_to_string(dir.path().join(".config/gtk-4.0/gtk.css")).unwrap();
+        let gtk3 = std::fs::read_to_string(dir.path().join(".config/gtk-3.0/gtk.css")).unwrap();
+        assert!(gtk4.contains("window_bg_color"), "GTK4 file missing GTK4 token");
+        assert!(!gtk4.contains("theme_bg_color"), "GTK4 file contaminated with GTK3 token");
+        assert!(gtk3.contains("theme_bg_color"), "GTK3 file missing GTK3 token");
+        assert!(!gtk3.contains("window_bg_color"), "GTK3 file contaminated with GTK4 token");
     }
 
     #[test]
@@ -158,7 +185,7 @@ mod tests {
         std::fs::create_dir_all(gtk4.parent().unwrap()).unwrap();
         std::fs::write(&gtk4, "/* user-authored */").unwrap();
 
-        writer.write_gtk_css("/* gnome-x */").unwrap();
+        writer.write_gtk_css("/* gnome-x */", "/* gnome-x-3 */").unwrap();
 
         let backup = dir
             .path()
@@ -180,7 +207,7 @@ mod tests {
         std::fs::create_dir_all(gtk4.parent().unwrap()).unwrap();
         std::fs::write(&gtk4, "/* GNOME X — Shell overrides */").unwrap();
 
-        writer.write_gtk_css("/* new */").unwrap();
+        writer.write_gtk_css("/* new */", "/* new-3 */").unwrap();
         let backup = dir
             .path()
             .join(".config/gtk-4.0/gtk.css.gnomex-backup");
@@ -196,7 +223,7 @@ mod tests {
         std::fs::create_dir_all(gtk4.parent().unwrap()).unwrap();
         std::fs::write(&gtk4, "/* user-authored */").unwrap();
 
-        writer.write_gtk_css("/* gnome-x */").unwrap();
+        writer.write_gtk_css("/* gnome-x */", "/* gnome-x-3 */").unwrap();
         writer.clear_overrides().unwrap();
 
         // Backup should be gone, gtk.css should hold the original.
@@ -217,7 +244,7 @@ mod tests {
         let writer = tmp_writer(dir.path());
 
         // No prior user file; writer writes its own, then clears.
-        writer.write_gtk_css("/* gnome-x */").unwrap();
+        writer.write_gtk_css("/* gnome-x */", "/* gnome-x-3 */").unwrap();
         writer.clear_overrides().unwrap();
 
         assert!(!dir.path().join(".config/gtk-4.0/gtk.css").exists());

--- a/crates/infra/tests/gtk3_css_divergence.rs
+++ b/crates/infra/tests/gtk3_css_divergence.rs
@@ -1,0 +1,338 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! GTK3 CSS divergence fixtures (GXF-001).
+//!
+//! Previously `ThemeCss` had a single `gtk_css` string that the writer
+//! dropped into *both* `gtk-4.0/gtk.css` and `gtk-3.0/gtk.css`. GTK3
+//! reads a different token namespace (`@theme_bg_color` rather than
+//! `@window_bg_color`) and a different widget tree (`.sidebar` rather
+//! than `.navigation-sidebar`, no `.card`, no `splitview`, no
+//! `popover > contents`), so the byte-identical output was mostly a
+//! no-op and sometimes actively worse than vanilla Adwaita.
+//!
+//! These tests pin the core invariants of the divergence:
+//!
+//! 1. **Marker present.** Every generator's GTK3 output contains the
+//!    literal `"GNOME X"` substring so the conflict detector doesn't
+//!    false-positive-flag our own file the moment a user applies a theme.
+//! 2. **Legacy tokens.** The GTK3 output defines the `@theme_*` tokens
+//!    GTK3 actually honours, not the Libadwaita-only `@window_*` tokens.
+//! 3. **No GTK4-only selectors.** The GTK3 output does NOT reference
+//!    `.navigation-sidebar`, `.card` (as a standalone class),
+//!    `splitview`, or `popover > contents`.
+//! 4. **Divergence from GTK4.** The GTK3 stylesheet must not equal the
+//!    GTK4 stylesheet — if it did, we'd have regressed on this issue.
+
+use gnomex_domain::{HexColor, ShellVersion, ThemeSpec, WidgetColorOverrides};
+use gnomex_infra::theme_css::create_css_generator;
+use gnomex_infra::theme_css::gtk3::Gtk3CssGenerator;
+use gnomex_app::ports::ThemeCssGenerator;
+
+fn all_supported_versions() -> Vec<ShellVersion> {
+    vec![
+        ShellVersion::new(45, 0),
+        ShellVersion::new(46, 0),
+        ShellVersion::new(47, 0),
+        ShellVersion::new(50, 0),
+    ]
+}
+
+#[test]
+fn gtk3_css_contains_managed_region_marker() {
+    // If this assertion ever fails, the conflict detector will raise a
+    // spurious "unmanaged gtk.css" warning for *every* user the moment
+    // they apply a theme. The marker is load-bearing.
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&ThemeSpec::defaults()).unwrap();
+        assert!(
+            css.gtk3_css.contains("GNOME X"),
+            "{}: gtk3_css is missing the `GNOME X` managed-region marker — \
+             conflict detector will false-positive every user.\n----\n{}",
+            generator.version_label(),
+            css.gtk3_css,
+        );
+    }
+}
+
+#[test]
+fn gtk3_css_uses_legacy_theme_tokens() {
+    // `@theme_bg_color` / `@theme_base_color` are the tokens GTK3
+    // actually honours. The Libadwaita `@window_bg_color` / `@view_bg_color`
+    // pair is a no-op under GTK3.
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&ThemeSpec::defaults()).unwrap();
+        assert!(
+            css.gtk3_css.contains("@define-color theme_bg_color"),
+            "{}: gtk3_css does not define `@theme_bg_color`.\n----\n{}",
+            generator.version_label(),
+            css.gtk3_css,
+        );
+        assert!(
+            css.gtk3_css.contains("@define-color theme_base_color"),
+            "{}: gtk3_css does not define `@theme_base_color`.\n----\n{}",
+            generator.version_label(),
+            css.gtk3_css,
+        );
+        assert!(
+            css.gtk3_css.contains("@define-color theme_selected_bg_color"),
+            "{}: gtk3_css does not define `@theme_selected_bg_color`.\n----\n{}",
+            generator.version_label(),
+            css.gtk3_css,
+        );
+    }
+}
+
+#[test]
+fn gtk3_css_omits_libadwaita_only_tokens() {
+    // `@window_bg_color`, `@view_bg_color`, `@accent_bg_color`,
+    // `@card_bg_color`, `@popover_bg_color` are Libadwaita-only named
+    // colours; GTK3 logs CSS-parser warnings for every undefined one.
+    let forbidden_define = [
+        "@define-color window_bg_color",
+        "@define-color view_bg_color",
+        "@define-color card_bg_color",
+        "@define-color popover_bg_color",
+        "@define-color headerbar_backdrop_color",
+    ];
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&ThemeSpec::defaults()).unwrap();
+        for token in forbidden_define {
+            assert!(
+                !css.gtk3_css.contains(token),
+                "{}: gtk3_css emits GTK4-only token `{token}`.\n----\n{}",
+                generator.version_label(),
+                css.gtk3_css,
+            );
+        }
+    }
+}
+
+#[test]
+fn gtk3_css_does_not_reference_gtk4_only_selectors() {
+    // These selectors exist only in GTK4/Libadwaita. Emitting them
+    // to GTK3 pollutes parser logs and achieves nothing.
+    let forbidden_selectors = [
+        ".navigation-sidebar",
+        "splitview",
+        "popover > contents",
+    ];
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&ThemeSpec::defaults()).unwrap();
+        for selector in forbidden_selectors {
+            assert!(
+                !css.gtk3_css.contains(selector),
+                "{}: gtk3_css references GTK4-only selector `{selector}`.\n----\n{}",
+                generator.version_label(),
+                css.gtk3_css,
+            );
+        }
+        // `.card` is tolerated inside documentation strings like
+        // "GTK3 has no `.card` class", but must not appear as a CSS
+        // selector on its own line.
+        for line in css.gtk3_css.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("/*") || trimmed.starts_with("*") {
+                continue;
+            }
+            assert!(
+                !trimmed.starts_with(".card "),
+                "{}: gtk3_css uses `.card` as a selector (GTK3 has no `.card` class). Line: `{line}`\n----\n{}",
+                generator.version_label(),
+                css.gtk3_css,
+            );
+        }
+    }
+}
+
+#[test]
+fn gtk3_css_diverges_from_gtk4_css() {
+    // The core promise of this feature: the two payloads are
+    // different. If this assertion ever fails we've regressed all the
+    // way back to byte-identical dual rendering.
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&ThemeSpec::defaults()).unwrap();
+        assert_ne!(
+            css.gtk_css, css.gtk3_css,
+            "{}: gtk_css and gtk3_css are byte-identical — this is the bug GXF-001 fixes.",
+            generator.version_label(),
+        );
+    }
+}
+
+#[test]
+fn gtk3_css_translates_radius_knobs() {
+    let spec = ThemeSpec::defaults();
+    let window_r = spec.window_radius.as_i32();
+    let element_r = spec.element_radius.as_i32();
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        assert!(
+            css.gtk3_css.contains(&format!("border-radius: {window_r}px")),
+            "{}: window radius {window_r}px missing from gtk3_css",
+            generator.version_label(),
+        );
+        assert!(
+            css.gtk3_css
+                .contains(&format!("button {{ border-radius: {element_r}px; }}")),
+            "{}: button border-radius ({element_r}px) missing from gtk3_css\n----\n{}",
+            generator.version_label(),
+            css.gtk3_css,
+        );
+    }
+}
+
+#[test]
+fn gtk3_css_translates_headerbar_knobs() {
+    let spec = ThemeSpec::defaults();
+    let hb_height = spec.headerbar.min_height.as_i32();
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        // Must target both `headerbar` and `.titlebar` — GTK3 apps
+        // written before GTK 3.10 still use `.titlebar`.
+        assert!(
+            css.gtk3_css.contains("headerbar, .titlebar"),
+            "{}: gtk3_css headerbar selector missing `.titlebar` fallback\n----\n{}",
+            generator.version_label(),
+            css.gtk3_css,
+        );
+        assert!(
+            css.gtk3_css
+                .contains(&format!("min-height: {hb_height}px")),
+            "{}: gtk3_css missing headerbar min-height {hb_height}px",
+            generator.version_label(),
+        );
+    }
+}
+
+#[test]
+fn gtk3_css_translates_sidebar_fg_override_to_gtk3_selector() {
+    // The user's sidebar fg colour must hit `.sidebar` (the GTK3 class),
+    // NOT `.navigation-sidebar` (the GTK4 class). If it hit only the
+    // GTK4 class under GTK3 the user's colour would be silently ignored.
+    let mut spec = ThemeSpec::defaults();
+    spec.sidebar.fg_override = Some(HexColor::new("#abcdef").unwrap());
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        assert!(
+            css.gtk3_css.contains(".sidebar") && css.gtk3_css.contains("#abcdef"),
+            "{}: gtk3_css sidebar fg override missing\n----\n{}",
+            generator.version_label(),
+            css.gtk3_css,
+        );
+        // And the GTK4-only class must NOT be used.
+        assert!(
+            !css.gtk3_css.contains(".navigation-sidebar"),
+            "{}: gtk3_css sidebar fg leaked onto GTK4-only class",
+            generator.version_label(),
+        );
+    }
+}
+
+#[test]
+fn gtk3_css_translates_layer_separation_to_gtk3_selectors() {
+    let mut spec = ThemeSpec::defaults();
+    spec.layers.headerbar_bottom = gnomex_domain::Radius::new(2.0).unwrap();
+    spec.layers.sidebar_divider = gnomex_domain::Radius::new(1.0).unwrap();
+    // content_contrast is intentionally left at 0 — GTK3 has no
+    // `.content-pane` / `splitview` tree to attach contrast to.
+    for version in all_supported_versions() {
+        let generator = create_css_generator(&version);
+        let css = generator.generate(&spec).unwrap();
+        assert!(
+            css.gtk3_css.contains("headerbar, .titlebar { border-bottom: 2px"),
+            "{}: gtk3_css headerbar-bottom divider missing\n----\n{}",
+            generator.version_label(),
+            css.gtk3_css,
+        );
+        assert!(
+            css.gtk3_css.contains(".sidebar") && css.gtk3_css.contains("border-right: 1px"),
+            "{}: gtk3_css sidebar divider missing\n----\n{}",
+            generator.version_label(),
+            css.gtk3_css,
+        );
+    }
+}
+
+#[test]
+fn gtk3_css_widget_style_uses_gtk3_button_selector_without_libadwaita_filters() {
+    // GTK3's button widget has `.flat` but not `.suggested-action` /
+    // `.destructive-action` (those are Libadwaita classes). The
+    // button-raise selector must therefore NOT carry those filters
+    // (they'd silently match nothing in GTK3 and confuse future readers).
+    let mut spec = ThemeSpec::defaults();
+    spec.widget_style.button_raise = gnomex_domain::Opacity::from_fraction(0.5).unwrap();
+    let generator = Gtk3CssGenerator;
+    let css = generator.generate(&spec).unwrap();
+    assert!(
+        css.gtk3_css.contains("button:not(.flat)"),
+        "gtk3_css button-raise selector missing `button:not(.flat)`\n----\n{}",
+        css.gtk3_css,
+    );
+    assert!(
+        !css.gtk3_css.contains(":not(.suggested-action)"),
+        "gtk3_css leaks Libadwaita-only `.suggested-action` filter\n----\n{}",
+        css.gtk3_css,
+    );
+    assert!(
+        !css.gtk3_css.contains(":not(.destructive-action)"),
+        "gtk3_css leaks Libadwaita-only `.destructive-action` filter\n----\n{}",
+        css.gtk3_css,
+    );
+}
+
+#[test]
+fn gtk3_css_widget_colors_collapse_scheme_variants() {
+    // GTK 3.24 has no `prefers-color-scheme` media query, so the
+    // generator picks one variant based on the panel-tint luminance.
+    // With the default dark panel tint, the dark-variant overrides win.
+    let mut spec = ThemeSpec::defaults();
+    spec.widget_colors = WidgetColorOverrides {
+        button_bg_light: Some(HexColor::new("#ffffff").unwrap()),
+        button_bg_dark: Some(HexColor::new("#111111").unwrap()),
+        ..Default::default()
+    };
+    let generator = Gtk3CssGenerator;
+    let css = generator.generate(&spec).unwrap();
+
+    assert!(
+        css.gtk3_css.contains("#111111"),
+        "gtk3_css widget-colour override should pick dark-variant under default dark panel tint\n----\n{}",
+        css.gtk3_css,
+    );
+    // GTK3 output has no @media guards for prefers-color-scheme —
+    // pinning this invariant prevents a future refactor from silently
+    // adding one (which would parse-error under GTK 3.24).
+    assert!(
+        !css.gtk3_css.contains("prefers-color-scheme"),
+        "gtk3_css must not emit prefers-color-scheme guards — GTK 3.24 does not support them.\n----\n{}",
+        css.gtk3_css,
+    );
+}
+
+#[test]
+fn gtk3_css_is_emitted_even_when_panel_tint_is_light() {
+    // Regression guard: the scheme heuristic must not accidentally
+    // short-circuit the generator to an empty string when the user
+    // picks a pale panel tint.
+    let mut spec = ThemeSpec::defaults();
+    spec.panel.tint = HexColor::new("#f5f5f5").unwrap();
+    let generator = Gtk3CssGenerator;
+    let css = generator.generate(&spec).unwrap();
+    assert!(
+        css.gtk3_css.contains("GNOME X"),
+        "GTK3 marker missing under light panel tint"
+    );
+    assert!(
+        css.gtk3_css.contains("@define-color theme_bg_color"),
+        "GTK3 tint tokens missing under light panel tint"
+    );
+}


### PR DESCRIPTION
## Summary

Split the theme writer's output so GTK 4 and GTK 3 receive toolkit-appropriate CSS instead of the same Libadwaita-flavoured stylesheet.

- New `crates/infra/src/theme_css/gtk3.rs` emits legacy `@theme_*` tokens against `entry`, `button`, `.sidebar`, `.titlebar`, `headerbar`, `window.csd`, etc.
- `ThemeCss` gains a `gtk3_css: String` field. `ThemeWriter::write_gtk_css` takes both payloads separately and routes each to the correct XDG path. All four version generators (gnome45/46/47/50) fill `gtk3_css` via the shared helper.
- GTK3 output embeds the `"GNOME X"` managed-region marker so PR #40's conflict detector doesn't false-positive on our own file.

## Why

Today the theme writer drops the same Libadwaita stylesheet into both `~/.config/gtk-4.0/gtk.css` and `~/.config/gtk-3.0/gtk.css`. GTK 3 uses `@theme_bg_color` / `@theme_base_color`, not `@window_bg_color` / `@view_bg_color`; has no `.card`, no `splitview`, no `popover > contents`, no `:focus-visible`, and no `prefers-color-scheme`. The GTK3 half has therefore been largely a no-op and occasionally worse than vanilla Adwaita, which blocked Electron/Chromium/legacy-Gtk integration and pack-level dual-CSS (issues #8 and #28).

## Scope trade-offs

- **Extended `ThemeCss` rather than a second port.** Smallest blast radius — one extra field, one new call-site, four adapters updated.
- **Single GTK3 generator, not a per-version matrix.** GTK 3.24 is the last stable line; Electron / Chromium / legacy utilities all ship against it. One generator covers the lot.
- **`widget_colors.*` collapses light/dark into one variant** because GTK 3.24 does not understand `@media (prefers-color-scheme: ...)`. The panel-tint luminance picks which of the two to honour. Documented in the `gtk3.rs` module doc.

## What translates vs. doesn't

**Translates:** `tint`, `window_radius`/`element_radius`, `headerbar.*`, `window_frame.*`, `insets.{card_border_width,separator_opacity,focus_ring_width,combo_inset}`, `widget_style.*`, `widget_colors.*` (single variant), `foreground.*`, `sidebar.{opacity,fg_override}`, `layers.{headerbar_bottom,sidebar_divider}`, `status_colors.*`.

**Does NOT translate:** `layers.content_contrast` (no GTK3 `.content-pane`/`splitview`), `notifications.*`/`panel.*`/`dash.*`/`overview_blur` (shell-only), per-scheme widget-colour isolation, and the Libadwaita-only tokens `@headerbar_backdrop_color` / `@card_bg_color` / `@popover_bg_color`.

## Test plan

- [x] `cargo test --workspace` passes.
- [x] `cargo test --test gtk3_css_divergence` — 12/12 pass. Covers: marker present, legacy tokens used, absence of GTK4-only selectors, divergence from `gtk_css`, per-knob translation.
- [x] Existing writer-routing test updated for the new two-payload signature.
- [x] No existing test regressed.
- [x] Manually verify: apply a theme, inspect `~/.config/gtk-{3,4}.0/gtk.css` — different content, both carry the `"GNOME X"` marker. Open a GTK3 app (e.g. `gimp`, `inkscape`) and confirm the tint reaches it.

Closes #2