### PR TITLE
feat: Shadowed-resources diagnostics panel + SSD/CSD decoration probe

### DIFF
--- a/crates/app/src/ports/local_installer.rs
+++ b/crates/app/src/ports/local_installer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::AppError;
-use gnomex_domain::{ExtensionUuid, ThemeType};
+use gnomex_domain::{ExtensionUuid, ResourceKind, ShadowedResource, ThemeType};
 
 /// Port: install and uninstall content on the local filesystem.
 #[async_trait::async_trait]
@@ -35,4 +35,23 @@ pub trait LocalInstaller: Send + Sync {
     fn list_installed_icons(&self) -> Result<Vec<String>, AppError>;
 
     fn list_installed_cursors(&self) -> Result<Vec<String>, AppError>;
+
+    /// Enumerate every resource of the given [`ResourceKind`] that is
+    /// installed in more than one search-path location — the caller
+    /// can surface these so the user understands *which* of their
+    /// themes/icons/cursors is actually winning at GTK lookup time.
+    ///
+    /// Returns an empty vector when no shadowing is detected. Length-1
+    /// entries (not shadowed) are filtered out — every returned
+    /// [`ShadowedResource`] has `locations.len() >= 2`.
+    ///
+    /// See GXF-012. The default implementation returns `Ok(vec![])`
+    /// so existing test mocks of this trait keep compiling without
+    /// needing to stub the method.
+    fn list_shadowed_resources(
+        &self,
+        _kind: ResourceKind,
+    ) -> Result<Vec<ShadowedResource>, AppError> {
+        Ok(Vec::new())
+    }
 }

--- a/crates/app/src/ports/mod.rs
+++ b/crates/app/src/ports/mod.rs
@@ -20,6 +20,7 @@ mod shell_proxy;
 mod theme_css;
 mod theme_writer;
 mod theming_conflict_detector;
+mod window_decoration_probe;
 
 pub use app_settings::*;
 pub use appearance_settings::*;
@@ -35,3 +36,4 @@ pub use shell_proxy::*;
 pub use theme_css::*;
 pub use theme_writer::*;
 pub use theming_conflict_detector::*;
+pub use window_decoration_probe::*;

--- a/crates/app/src/ports/window_decoration_probe.rs
+++ b/crates/app/src/ports/window_decoration_probe.rs
@@ -1,0 +1,31 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Port: probe the running session for CSD vs SSD windows.
+//!
+//! Theme controls like headerbar height, window corner radius, and
+//! drop-shadow only reach apps that draw their own decorations
+//! (client-side). Server-side-decorated apps (legacy GTK 3 dialogs,
+//! Electron without Wayland decorations, Wine/Proton) get their
+//! titlebar from Mutter and are *not* re-themed by GNOME X.
+//!
+//! This port snapshots the current window list so the UI can warn the
+//! user which apps won't pick up the theme. Implementations are
+//! expected to be synchronous, fast (< 100 ms), and tolerant of
+//! windowing-backend quirks — returning an empty report is fine when
+//! no signal is available.
+//!
+//! See GXF-021.
+
+use gnomex_domain::DecorationReport;
+
+/// Snapshot probe for window decoration mode. Single method; no
+/// subscription / streaming API — the UI re-probes when the user
+/// opens the Theme Builder or Diagnostics view.
+pub trait WindowDecorationProbe: Send + Sync {
+    /// Inspect currently-open top-level windows and classify each as
+    /// CSD / SSD / Unknown. Implementations must never panic;
+    /// windowing-backend failures should surface as an empty report
+    /// rather than an error.
+    fn detect_decoration_mix(&self) -> DecorationReport;
+}

--- a/crates/domain/src/decoration_report.rs
+++ b/crates/domain/src/decoration_report.rs
@@ -1,0 +1,160 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Window decoration probe reports — classifies currently-open windows
+//! as CSD (client-side decorated, e.g. Libadwaita) vs SSD (server-side
+//! decorated, e.g. legacy GTK 3, Electron without Wayland decoration,
+//! Wine/Proton).
+//!
+//! Motivation: GNOME X's theme builder exposes controls like headerbar
+//! height, window corner radius, and CSD drop-shadow. **Those controls
+//! only reach apps that draw their own decorations.** SSD apps look
+//! unthemed no matter what — the window manager draws their titlebar
+//! using Mutter's own rules. Surfacing the mix lets users know which
+//! apps will and won't pick up the theme.
+//!
+//! See GXF-021. This is a *snapshot* report — probed once when the
+//! user opens the Theme Builder or Diagnostics view, not a live feed.
+
+/// How a single window is decorated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecorationMode {
+    /// Client-side decorations: the app draws its own titlebar.
+    /// GTK4 / Libadwaita / GTK3 with `AdwHeaderBar` all land here.
+    /// GNOME X's theme builder **does** reach these apps.
+    Csd,
+    /// Server-side decorations: Mutter draws the titlebar. Legacy GTK
+    /// 3 dialogs, Electron without `--ozone-platform-hint=auto` +
+    /// Wayland, Wine/Proton, some Qt apps without a GNOME platform
+    /// plugin. GNOME X's theme builder **does not** reach these.
+    Ssd,
+    /// Probe couldn't classify the window — toolkit unrecognised or
+    /// missing API access. Counted separately so we don't lie about
+    /// coverage.
+    Unknown,
+}
+
+impl DecorationMode {
+    pub fn label(&self) -> &'static str {
+        match self {
+            DecorationMode::Csd => "CSD",
+            DecorationMode::Ssd => "SSD",
+            DecorationMode::Unknown => "Unknown",
+        }
+    }
+}
+
+/// One window observed by the probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowDecorationInfo {
+    /// Window class / app-id as reported by the windowing system.
+    /// E.g. `"org.gnome.Nautilus"`, `"slack"`, `"Code"`.
+    pub app_class: String,
+    /// Human-readable window title at probe time. Best-effort — some
+    /// windowing backends don't expose this.
+    pub title: Option<String>,
+    pub mode: DecorationMode,
+}
+
+/// Aggregate report. `windows` is unsorted; consumers that render a
+/// list should sort by `mode` then `app_class` for stable UI.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DecorationReport {
+    pub windows: Vec<WindowDecorationInfo>,
+}
+
+impl DecorationReport {
+    /// Shorthand: how many SSD windows are open right now? Zero means
+    /// "the theme builder reaches everything you have open".
+    pub fn ssd_count(&self) -> usize {
+        self.windows
+            .iter()
+            .filter(|w| w.mode == DecorationMode::Ssd)
+            .count()
+    }
+
+    pub fn csd_count(&self) -> usize {
+        self.windows
+            .iter()
+            .filter(|w| w.mode == DecorationMode::Csd)
+            .count()
+    }
+
+    pub fn unknown_count(&self) -> usize {
+        self.windows
+            .iter()
+            .filter(|w| w.mode == DecorationMode::Unknown)
+            .count()
+    }
+
+    /// Distinct SSD app classes in a stable order — the "interesting"
+    /// list the banner surfaces ("Slack, Steam will not pick up the
+    /// headerbar styling").
+    pub fn ssd_app_classes(&self) -> Vec<String> {
+        let mut out: Vec<String> = self
+            .windows
+            .iter()
+            .filter(|w| w.mode == DecorationMode::Ssd)
+            .map(|w| w.app_class.clone())
+            .collect();
+        out.sort();
+        out.dedup();
+        out
+    }
+
+    /// True when any SSD window is present — the banner's gate.
+    pub fn has_ssd_windows(&self) -> bool {
+        self.ssd_count() > 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn win(class: &str, mode: DecorationMode) -> WindowDecorationInfo {
+        WindowDecorationInfo {
+            app_class: class.into(),
+            title: None,
+            mode,
+        }
+    }
+
+    #[test]
+    fn counts_tally_by_mode() {
+        let r = DecorationReport {
+            windows: vec![
+                win("org.gnome.Nautilus", DecorationMode::Csd),
+                win("org.gnome.TextEditor", DecorationMode::Csd),
+                win("slack", DecorationMode::Ssd),
+                win("steam", DecorationMode::Ssd),
+                win("weird", DecorationMode::Unknown),
+            ],
+        };
+        assert_eq!(r.csd_count(), 2);
+        assert_eq!(r.ssd_count(), 2);
+        assert_eq!(r.unknown_count(), 1);
+        assert!(r.has_ssd_windows());
+    }
+
+    #[test]
+    fn ssd_app_classes_are_sorted_and_deduped() {
+        let r = DecorationReport {
+            windows: vec![
+                win("steam", DecorationMode::Ssd),
+                win("slack", DecorationMode::Ssd),
+                win("slack", DecorationMode::Ssd), // second Slack window
+                win("org.gnome.Files", DecorationMode::Csd),
+            ],
+        };
+        assert_eq!(r.ssd_app_classes(), vec!["slack", "steam"]);
+    }
+
+    #[test]
+    fn empty_report_reports_no_ssd() {
+        let r = DecorationReport::default();
+        assert!(!r.has_ssd_windows());
+        assert_eq!(r.ssd_count(), 0);
+        assert_eq!(r.ssd_app_classes(), Vec::<String>::new());
+    }
+}

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -7,11 +7,13 @@
 //! business rules. This crate has **zero** external dependencies.
 
 pub mod color;
+mod decoration_report;
 mod error;
 mod extension;
 mod experience_pack;
 mod external_theme_spec;
 mod pack_compatibility;
+mod shadowed_resource;
 mod shell_tweak;
 mod shell_version;
 mod theme;
@@ -19,11 +21,13 @@ pub mod theme_capability;
 mod theme_spec;
 mod theming_conflict;
 
+pub use decoration_report::*;
 pub use error::*;
 pub use extension::*;
 pub use experience_pack::*;
 pub use external_theme_spec::*;
 pub use pack_compatibility::*;
+pub use shadowed_resource::*;
 pub use shell_tweak::*;
 pub use shell_version::*;
 pub use theme::*;

--- a/crates/domain/src/shadowed_resource.rs
+++ b/crates/domain/src/shadowed_resource.rs
@@ -1,0 +1,167 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shadowed resource reports — surfaced to the user when the same
+//! theme / icon pack / cursor is installed in more than one location
+//! on the XDG data search path.
+//!
+//! Per the freedesktop icon-theme spec (and GTK's theme lookup), the
+//! first path in search order wins; later copies are *shadowed*. A
+//! common user-visible failure: installing a theme to
+//! `~/.local/share/themes/<Name>` when `/usr/share/themes/<Name>`
+//! already exists and is earlier in the search order — the user's
+//! fresh install is silently masked.
+//!
+//! The [`crate::ShadowedResource`] value-object captures that
+//! situation as pure data; the infrastructure layer populates it by
+//! walking the actual filesystem. See GXF-012.
+
+use std::path::PathBuf;
+
+/// Which family of resource is being shadow-checked. Matches the three
+/// directory hierarchies GTK/GNOME scan independently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ResourceKind {
+    /// GTK widget themes — `themes/<Name>/gtk-N.N/gtk.css`.
+    Theme,
+    /// Icon themes — `icons/<Name>/index.theme`.
+    Icon,
+    /// Cursor themes — `icons/<Name>/cursors/`.
+    Cursor,
+}
+
+impl ResourceKind {
+    /// Short, user-facing label ("Theme", "Icon pack", "Cursor").
+    pub fn label(&self) -> &'static str {
+        match self {
+            ResourceKind::Theme => "Theme",
+            ResourceKind::Icon => "Icon pack",
+            ResourceKind::Cursor => "Cursor",
+        }
+    }
+
+    /// XDG-style subdirectory name (`"themes"` / `"icons"`).
+    pub fn xdg_subdir(&self) -> &'static str {
+        match self {
+            ResourceKind::Theme => "themes",
+            // Cursors live under icons/<Name>/cursors — they share the
+            // icons directory tree, but are discriminated in the
+            // shadow walk by the presence of a `cursors/` subdir.
+            ResourceKind::Icon | ResourceKind::Cursor => "icons",
+        }
+    }
+}
+
+/// One place on disk where a resource lives.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowedLocation {
+    pub path: PathBuf,
+    /// `true` when the directory is under `$XDG_DATA_HOME` or the
+    /// legacy `~/.themes` / `~/.icons` path — i.e. GNOME X (and the
+    /// user) can modify it without elevated privileges. `false` for
+    /// system dirs under `$XDG_DATA_DIRS` (typically `/usr/share/...`).
+    pub user_writable: bool,
+}
+
+/// A named resource that appears in more than one search path. The
+/// `locations` vector is **ordered by search precedence** — the first
+/// entry is the one GTK/GNOME resolves to; all subsequent entries are
+/// masked copies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowedResource {
+    pub kind: ResourceKind,
+    /// The directory name (e.g. `"Adwaita"`, `"Yaru-blue"`) — this is
+    /// what the user and GSettings refer to the resource by.
+    pub name: String,
+    /// All matching locations, winning one first. Length >= 2 by
+    /// construction (length-1 lists are not shadowed — callers should
+    /// filter before surfacing).
+    pub locations: Vec<ShadowedLocation>,
+}
+
+impl ShadowedResource {
+    /// The location GTK will actually resolve to. Always the first
+    /// entry since `locations` is sorted in search order.
+    pub fn winning_location(&self) -> &ShadowedLocation {
+        // Invariant: `locations` is never empty — a ShadowedResource
+        // only makes sense with at least two entries. Callers that
+        // build this struct must uphold that.
+        &self.locations[0]
+    }
+
+    /// Locations that are masked by the winner. Always `locations[1..]`.
+    pub fn masked_locations(&self) -> &[ShadowedLocation] {
+        &self.locations[1..]
+    }
+
+    /// Heuristic: the most common user-confusing case is a fresh
+    /// install to the user-writable path that loses to an older
+    /// system-wide copy. This returns `true` when the winner is
+    /// system-wide but a user-writable copy also exists.
+    pub fn user_install_masked(&self) -> bool {
+        !self.winning_location().user_writable
+            && self.masked_locations().iter().any(|l| l.user_writable)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loc(path: &str, writable: bool) -> ShadowedLocation {
+        ShadowedLocation {
+            path: PathBuf::from(path),
+            user_writable: writable,
+        }
+    }
+
+    #[test]
+    fn winning_location_is_first_entry() {
+        let r = ShadowedResource {
+            kind: ResourceKind::Theme,
+            name: "Adwaita".into(),
+            locations: vec![
+                loc("/home/u/.local/share/themes/Adwaita", true),
+                loc("/usr/share/themes/Adwaita", false),
+            ],
+        };
+        assert_eq!(r.winning_location().path, PathBuf::from("/home/u/.local/share/themes/Adwaita"));
+        assert_eq!(r.masked_locations().len(), 1);
+    }
+
+    #[test]
+    fn user_install_masked_flags_the_common_failure_case() {
+        // System copy wins because the user's copy is actually on an
+        // unusual path ordering (e.g. XDG_DATA_DIRS includes user dir
+        // at a lower-priority slot) — or more realistically: the user
+        // installed the theme to ~/.themes but their gtk version only
+        // honours /usr/share/themes for shell themes.
+        let system_wins = ShadowedResource {
+            kind: ResourceKind::Theme,
+            name: "Yaru".into(),
+            locations: vec![
+                loc("/usr/share/themes/Yaru", false),
+                loc("/home/u/.local/share/themes/Yaru", true),
+            ],
+        };
+        assert!(system_wins.user_install_masked());
+
+        let user_wins = ShadowedResource {
+            kind: ResourceKind::Theme,
+            name: "Yaru".into(),
+            locations: vec![
+                loc("/home/u/.local/share/themes/Yaru", true),
+                loc("/usr/share/themes/Yaru", false),
+            ],
+        };
+        assert!(!user_wins.user_install_masked());
+    }
+
+    #[test]
+    fn kind_labels_and_subdirs() {
+        assert_eq!(ResourceKind::Theme.xdg_subdir(), "themes");
+        assert_eq!(ResourceKind::Icon.xdg_subdir(), "icons");
+        assert_eq!(ResourceKind::Cursor.xdg_subdir(), "icons");
+        assert_eq!(ResourceKind::Cursor.label(), "Cursor");
+    }
+}

--- a/crates/infra/src/filesystem_installer.rs
+++ b/crates/infra/src/filesystem_installer.rs
@@ -1,10 +1,12 @@
 // Copyright 2026 GNOME X Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::theme_paths::{list_all, ResourcePaths};
+use crate::theme_paths::{list_all, shadow_map, ResourcePaths, SearchPath};
 use gnomex_app::ports::LocalInstaller;
 use gnomex_app::AppError;
-use gnomex_domain::{ExtensionUuid, ThemeType};
+use gnomex_domain::{
+    ExtensionUuid, ResourceKind, ShadowedLocation, ShadowedResource, ThemeType,
+};
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
@@ -37,6 +39,14 @@ impl FilesystemInstaller {
             data_dir,
             paths: ResourcePaths::from_env(),
         }
+    }
+
+    /// Hermetic constructor for tests — wire an explicit `data_dir`
+    /// (where new installs land) and a fully-formed [`ResourcePaths`]
+    /// (what gets walked for listings / shadow detection). Lets
+    /// tests run in parallel without racing `$HOME` / `$XDG_*`.
+    pub fn with_paths(data_dir: PathBuf, paths: ResourcePaths) -> Self {
+        Self { data_dir, paths }
     }
 
     fn extensions_dir(&self) -> PathBuf {
@@ -163,6 +173,52 @@ impl LocalInstaller for FilesystemInstaller {
         cursors.sort();
         cursors.dedup();
         Ok(cursors)
+    }
+
+    fn list_shadowed_resources(
+        &self,
+        kind: ResourceKind,
+    ) -> Result<Vec<ShadowedResource>, AppError> {
+        let search = match kind {
+            ResourceKind::Theme => self.paths.themes(),
+            ResourceKind::Icon => self.paths.icons(),
+            ResourceKind::Cursor => self.paths.cursors(),
+        };
+        let map = shadow_map(&search);
+        let mut out = Vec::new();
+        for (name, locs) in map {
+            if locs.len() < 2 {
+                continue;
+            }
+            // For cursors, discard names whose directory doesn't have
+            // a `cursors/` subdir in *any* location — those are
+            // icon-only entries we don't want to confuse the cursor
+            // report with.
+            if kind == ResourceKind::Cursor
+                && !locs
+                    .iter()
+                    .any(|sp: &SearchPath| sp.path.join(&name).join("cursors").is_dir())
+            {
+                continue;
+            }
+            // shadow_map returns the *parent* directory (e.g.
+            // `/usr/share/themes`); join the resource name onto each
+            // so the UI can surface the absolute path to the theme
+            // itself.
+            let locations = locs
+                .into_iter()
+                .map(|sp| ShadowedLocation {
+                    path: sp.path.join(&name),
+                    user_writable: sp.origin.is_user_writable(),
+                })
+                .collect();
+            out.push(ShadowedResource {
+                kind,
+                name,
+                locations,
+            });
+        }
+        Ok(out)
     }
 }
 

--- a/crates/infra/src/lib.rs
+++ b/crates/infra/src/lib.rs
@@ -23,6 +23,7 @@ pub mod theme_paths;
 mod theme_writer;
 mod theming_conflict_detector;
 mod vscode_themer;
+pub mod window_decoration_probe;
 
 pub use blur_my_shell::GSettingsBlurMyShell;
 pub use chromium_themer::ChromiumThemer;
@@ -37,3 +38,4 @@ pub use pack_toml_storage::PackTomlStorage;
 pub use theme_writer::FilesystemThemeWriter;
 pub use theming_conflict_detector::GioThemingConflictDetector;
 pub use vscode_themer::VscodeThemer;
+pub use window_decoration_probe::WmctrlDecorationProbe;

--- a/crates/infra/src/window_decoration_probe.rs
+++ b/crates/infra/src/window_decoration_probe.rs
@@ -1,0 +1,320 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pragmatic SSD/CSD probe for running top-level windows.
+//!
+//! There is no single clean cross-session API for "does this window
+//! draw its own decorations or let the WM do it?". GTK+Adwaita apps
+//! decorate themselves; legacy GTK 3 dialogs, Electron without
+//! `--enable-features=WaylandWindowDecorations`, Wine/Proton, and a
+//! handful of Qt apps without a GNOME platform plugin decorate
+//! server-side. Live on GNOME Wayland, the honest query would be
+//! `global.get_window_actors()` inside a Shell extension — and we do
+//! ship one, but not for this purpose.
+//!
+//! The MVP here uses the most portable signal available:
+//!
+//! 1. Run `wmctrl -lx` (X11/XWayland) to enumerate top-level windows
+//!    with their `WM_CLASS`. Most legacy SSD apps (Wine, Steam,
+//!    Electron without Wayland deco) run on XWayland and are visible.
+//! 2. Classify each `WM_CLASS` against two curated heuristic lists:
+//!    - Known-CSD toolkits: `org.gnome.*`, `Adwaita`, `io.github.*`,
+//!      generic GTK/Libadwaita app-IDs.
+//!    - Known-SSD toolkits: Electron apps (Slack, Discord, VS Code
+//!      without `--ozone-platform=wayland`), Wine, Steam, Java/AWT.
+//!
+//! When `wmctrl` isn't installed or the classification heuristic
+//! returns `Unknown`, we degrade gracefully: an empty report or a
+//! report with `Unknown` entries. The UI treats missing data as
+//! "no SSD signal, don't show the banner".
+//!
+//! **Trade-off acknowledged:** this is a heuristic; false negatives
+//! are expected (apps with unusual `WM_CLASS`). False positives
+//! (flagging a CSD app as SSD) are avoided by being conservative —
+//! we only mark `Ssd` when we have strong signal.
+//!
+//! Testing: [`probe_with_runner`] accepts an injectable window-list
+//! source so the classification logic is fully unit-testable without
+//! spawning subprocesses.
+
+use gnomex_app::ports::WindowDecorationProbe;
+use gnomex_domain::{DecorationMode, DecorationReport, WindowDecorationInfo};
+use std::process::Command;
+
+/// Single raw window record as observed from the windowing system.
+/// De-coupled from any particular command so the classifier is
+/// testable without process I/O.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawWindow {
+    pub app_class: String,
+    pub title: Option<String>,
+}
+
+/// Concrete probe that shells out to `wmctrl -lx`. Cheap to construct.
+///
+/// When `wmctrl` is not on `$PATH` (pure-Wayland session with no
+/// XWayland legacy fallback installed), `detect_decoration_mix`
+/// returns an empty report and logs at `debug` — the UI will simply
+/// not show the banner.
+pub struct WmctrlDecorationProbe;
+
+impl WmctrlDecorationProbe {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for WmctrlDecorationProbe {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WindowDecorationProbe for WmctrlDecorationProbe {
+    fn detect_decoration_mix(&self) -> DecorationReport {
+        match run_wmctrl() {
+            Ok(raws) => probe_with_runner(&raws),
+            Err(e) => {
+                tracing::debug!(
+                    "wmctrl decoration probe unavailable ({e}); returning empty report",
+                );
+                DecorationReport::default()
+            }
+        }
+    }
+}
+
+/// Classification entry point — pure function over the raw window
+/// list. Public so tests can feed synthetic input.
+pub fn probe_with_runner(raws: &[RawWindow]) -> DecorationReport {
+    let windows = raws
+        .iter()
+        .map(|raw| WindowDecorationInfo {
+            app_class: raw.app_class.clone(),
+            title: raw.title.clone(),
+            mode: classify(&raw.app_class),
+        })
+        .collect();
+    DecorationReport { windows }
+}
+
+/// Classify a single `WM_CLASS` / app-id. Conservative: returns
+/// `Unknown` rather than guessing when the class doesn't match either
+/// curated list.
+fn classify(app_class: &str) -> DecorationMode {
+    let lower = app_class.to_ascii_lowercase();
+
+    // SSD signals — these apps paint their own window chrome via the
+    // WM. Matched before CSD because some (e.g. "code" for VSCode)
+    // also look generic.
+    for needle in SSD_APP_CLASS_SUBSTRINGS {
+        if lower.contains(needle) {
+            return DecorationMode::Ssd;
+        }
+    }
+
+    // CSD signals — GNOME / Libadwaita app-ID prefixes are a strong
+    // signal. GTK4 apps using reverse-DNS IDs dominate this bucket.
+    for prefix in CSD_APP_CLASS_PREFIXES {
+        if lower.starts_with(prefix) {
+            return DecorationMode::Csd;
+        }
+    }
+    for needle in CSD_APP_CLASS_SUBSTRINGS {
+        if lower.contains(needle) {
+            return DecorationMode::Csd;
+        }
+    }
+
+    DecorationMode::Unknown
+}
+
+/// Substrings in `WM_CLASS` (lowercased) that indicate server-side
+/// decoration. Kept conservative — we'd rather admit "unknown" than
+/// falsely warn the user that a CSD app won't theme.
+const SSD_APP_CLASS_SUBSTRINGS: &[&str] = &[
+    // Electron apps that don't opt into Wayland CSD.
+    "slack",
+    "discord",
+    "signal",
+    "obsidian",
+    "spotify",
+    // Wine / Proton virtual windows.
+    "wine",
+    "explorer.exe",
+    // Steam client.
+    "steam",
+    // Java AWT/Swing legacy.
+    "sun-awt",
+    // XTerm family (classic SSD terminal emulators).
+    "xterm",
+    "uxterm",
+];
+
+/// Prefixes in app-ID (lowercased) strongly indicating a GNOME / GTK4
+/// / Libadwaita CSD app.
+const CSD_APP_CLASS_PREFIXES: &[&str] = &[
+    "org.gnome.",
+    "io.github.gnomex.",
+    "io.github.",
+    "org.gtk.",
+    "org.freedesktop.",
+    "net.nokyan.",   // Resources
+    "com.belmoussaoui.",
+    "app.drey.",
+    "de.haeckerfelix.",
+];
+
+/// Free-form substrings that also indicate CSD — catches common
+/// app-IDs that don't fit a prefix.
+const CSD_APP_CLASS_SUBSTRINGS: &[&str] = &[
+    "nautilus",
+    "gnome-text-editor",
+    "gnome-terminal",
+    "gnome-calculator",
+    "gnome-weather",
+    "gnome-clocks",
+    "gnome-maps",
+    "gnome-control-center",
+    "gedit",
+    "epiphany",
+    "evince",
+    "eog",
+    "gnome-software",
+];
+
+/// Spawn `wmctrl -lx` and parse its stdout into [`RawWindow`]s. The
+/// command emits one line per window:
+///
+/// ```text
+/// 0x04200003 -1 org.gnome.Nautilus.Org.gnome.Nautilus hostname Files
+/// ```
+///
+/// We want columns 3 (`WM_CLASS`) and 5+ (title).
+fn run_wmctrl() -> Result<Vec<RawWindow>, String> {
+    let output = Command::new("wmctrl")
+        .arg("-lx")
+        .output()
+        .map_err(|e| format!("spawn failed: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "wmctrl exited {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr),
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_wmctrl_output(&stdout))
+}
+
+/// Pure parser — split out for testability. wmctrl pads columns with
+/// variable whitespace, so we tokenise via `split_whitespace` and
+/// take the first four tokens as the fixed-width prefix (id, desktop,
+/// WM_CLASS, hostname). Everything after the hostname is the title.
+pub fn parse_wmctrl_output(stdout: &str) -> Vec<RawWindow> {
+    stdout
+        .lines()
+        .filter_map(|line| {
+            if line.trim().is_empty() {
+                return None;
+            }
+            let cols: Vec<&str> = line.split_whitespace().collect();
+            if cols.len() < 4 {
+                return None;
+            }
+            let wm_class = cols[2].to_string();
+            if wm_class.is_empty() {
+                return None;
+            }
+            let title = if cols.len() > 4 {
+                Some(cols[4..].join(" "))
+            } else {
+                None
+            }
+            .filter(|s| !s.is_empty());
+            Some(RawWindow {
+                app_class: wm_class,
+                title,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_known_csd_apps() {
+        assert_eq!(classify("org.gnome.Nautilus.Org.gnome.Nautilus"), DecorationMode::Csd);
+        assert_eq!(classify("io.github.gnomex.GnomeX.io.github.gnomex.GnomeX"), DecorationMode::Csd);
+        assert_eq!(classify("gedit.Gedit"), DecorationMode::Csd);
+    }
+
+    #[test]
+    fn classifies_known_ssd_apps() {
+        assert_eq!(classify("slack.Slack"), DecorationMode::Ssd);
+        assert_eq!(classify("steam.Steam"), DecorationMode::Ssd);
+        assert_eq!(classify("xterm.XTerm"), DecorationMode::Ssd);
+        assert_eq!(classify("discord.discord"), DecorationMode::Ssd);
+    }
+
+    #[test]
+    fn classifies_unknown_toolkits_as_unknown() {
+        // Conservative: we don't know, so we don't falsely warn.
+        assert_eq!(classify("some-mystery-app.Whatever"), DecorationMode::Unknown);
+        assert_eq!(classify(""), DecorationMode::Unknown);
+    }
+
+    #[test]
+    fn probe_with_runner_produces_expected_report() {
+        let raws = vec![
+            RawWindow {
+                app_class: "org.gnome.Nautilus.Org.gnome.Nautilus".into(),
+                title: Some("Files".into()),
+            },
+            RawWindow {
+                app_class: "slack.Slack".into(),
+                title: Some("Slack | General".into()),
+            },
+            RawWindow {
+                app_class: "mystery.Unknown".into(),
+                title: None,
+            },
+        ];
+        let report = probe_with_runner(&raws);
+        assert_eq!(report.csd_count(), 1);
+        assert_eq!(report.ssd_count(), 1);
+        assert_eq!(report.unknown_count(), 1);
+        assert!(report.has_ssd_windows());
+        assert_eq!(report.ssd_app_classes(), vec!["slack.Slack".to_string()]);
+    }
+
+    #[test]
+    fn parse_wmctrl_output_extracts_class_and_title() {
+        let sample = "0x04200003 -1 org.gnome.Nautilus.Org.gnome.Nautilus hostname Files\n\
+                      0x04400004  0 slack.Slack  hostname Slack | General\n";
+        let raws = parse_wmctrl_output(sample);
+        assert_eq!(raws.len(), 2);
+        assert_eq!(raws[0].app_class, "org.gnome.Nautilus.Org.gnome.Nautilus");
+        assert_eq!(raws[0].title.as_deref(), Some("Files"));
+        assert_eq!(raws[1].app_class, "slack.Slack");
+    }
+
+    #[test]
+    fn parse_wmctrl_output_tolerates_missing_fields() {
+        // Windows with no title — wmctrl emits just four fields.
+        let sample = "0x04200003 -1 foo.Foo hostname";
+        let raws = parse_wmctrl_output(sample);
+        assert_eq!(raws.len(), 1);
+        assert_eq!(raws[0].app_class, "foo.Foo");
+        assert!(raws[0].title.is_none());
+    }
+
+    #[test]
+    fn parse_wmctrl_output_skips_blank_lines() {
+        let sample = "\n0x04200003 -1 org.gnome.Files.Org.gnome.Files host Files\n\n";
+        let raws = parse_wmctrl_output(sample);
+        assert_eq!(raws.len(), 1);
+    }
+}

--- a/crates/infra/tests/shadowed_resources.rs
+++ b/crates/infra/tests/shadowed_resources.rs
@@ -1,0 +1,135 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Hermetic integration test for
+//! `FilesystemInstaller::list_shadowed_resources`. Uses
+//! [`ResourcePaths::explicit`] + [`FilesystemInstaller::with_paths`]
+//! so nothing depends on `$HOME` / `$XDG_*` — safe to run in parallel
+//! with every other test in the workspace.
+//!
+//! See GXF-012.
+
+use gnomex_app::ports::LocalInstaller;
+use gnomex_domain::ResourceKind;
+use gnomex_infra::theme_paths::ResourcePaths;
+use gnomex_infra::FilesystemInstaller;
+use std::fs;
+use std::path::PathBuf;
+
+fn make_installer(root: &std::path::Path) -> (FilesystemInstaller, PathBuf, PathBuf, PathBuf) {
+    // Build a fake XDG layout under `root`:
+    //   root/user/.local/share/{themes,icons}   (user-writable)
+    //   root/system/share/{themes,icons}        (system)
+    let user_data = root.join("user/.local/share");
+    let user_legacy_themes = root.join("user/.themes");
+    let user_legacy_icons = root.join("user/.icons");
+    let sys = root.join("system/share");
+    fs::create_dir_all(user_data.join("themes")).unwrap();
+    fs::create_dir_all(user_data.join("icons")).unwrap();
+    fs::create_dir_all(&user_legacy_themes).unwrap();
+    fs::create_dir_all(&user_legacy_icons).unwrap();
+    fs::create_dir_all(sys.join("themes")).unwrap();
+    fs::create_dir_all(sys.join("icons")).unwrap();
+    let paths = ResourcePaths::explicit(
+        root.join("user"),
+        user_data.clone(),
+        vec![sys.clone()],
+        root.join("user/.config"),
+    );
+    let installer = FilesystemInstaller::with_paths(user_data.clone(), paths);
+    (installer, user_data, sys, user_legacy_themes)
+}
+
+#[test]
+fn detects_theme_shadowed_between_user_and_system() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (installer, user_data, sys, _legacy_themes) = make_installer(tmp.path());
+
+    // "Yaru" installed in both user and system.
+    fs::create_dir_all(user_data.join("themes/Yaru")).unwrap();
+    fs::create_dir_all(sys.join("themes/Yaru")).unwrap();
+    // "OnlyUser" in user only — not shadowed.
+    fs::create_dir_all(user_data.join("themes/OnlyUser")).unwrap();
+
+    let shadowed = installer
+        .list_shadowed_resources(ResourceKind::Theme)
+        .unwrap();
+    assert_eq!(shadowed.len(), 1, "only Yaru should be shadowed");
+    let yaru = &shadowed[0];
+    assert_eq!(yaru.name, "Yaru");
+    assert_eq!(yaru.kind, ResourceKind::Theme);
+    assert_eq!(yaru.locations.len(), 2);
+    // User location wins (first in XDG order).
+    let winner = yaru.winning_location();
+    assert!(winner.user_writable);
+    assert_eq!(winner.path, user_data.join("themes/Yaru"));
+    // System location is masked.
+    let masked = &yaru.masked_locations()[0];
+    assert!(!masked.user_writable);
+    assert_eq!(masked.path, sys.join("themes/Yaru"));
+}
+
+#[test]
+fn returns_empty_when_nothing_is_shadowed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (installer, user_data, _sys, _legacy) = make_installer(tmp.path());
+    fs::create_dir_all(user_data.join("themes/UniqueTheme")).unwrap();
+
+    let shadowed = installer
+        .list_shadowed_resources(ResourceKind::Theme)
+        .unwrap();
+    assert!(shadowed.is_empty());
+}
+
+#[test]
+fn detects_icon_pack_shadowed_across_legacy_and_xdg() {
+    // The legacy ~/.icons path ought to shadow/mask icons found also
+    // under the system /usr/share/icons path. ~/.local/share/icons
+    // still wins overall. Verify ordering is XDG user > legacy ~ >
+    // system.
+    let tmp = tempfile::tempdir().unwrap();
+    let (installer, user_data, sys, _legacy_themes) = make_installer(tmp.path());
+    let legacy_icons = tmp.path().join("user/.icons");
+
+    fs::create_dir_all(user_data.join("icons/Papirus")).unwrap();
+    fs::create_dir_all(legacy_icons.join("Papirus")).unwrap();
+    fs::create_dir_all(sys.join("icons/Papirus")).unwrap();
+
+    let shadowed = installer
+        .list_shadowed_resources(ResourceKind::Icon)
+        .unwrap();
+    assert_eq!(shadowed.len(), 1);
+    let p = &shadowed[0];
+    assert_eq!(p.name, "Papirus");
+    assert_eq!(p.locations.len(), 3);
+    // Order: XDG user, legacy ~/.icons, system.
+    assert_eq!(p.locations[0].path, user_data.join("icons/Papirus"));
+    assert_eq!(p.locations[1].path, legacy_icons.join("Papirus"));
+    assert_eq!(p.locations[2].path, sys.join("icons/Papirus"));
+    assert!(p.locations[0].user_writable);
+    assert!(p.locations[1].user_writable);
+    assert!(!p.locations[2].user_writable);
+}
+
+#[test]
+fn cursor_kind_only_returns_entries_with_cursors_subdir() {
+    // A name present as an icon-only theme in both locations must NOT
+    // show up as a shadowed cursor. Only names with a `cursors/`
+    // subdir somewhere should.
+    let tmp = tempfile::tempdir().unwrap();
+    let (installer, user_data, sys, _legacy) = make_installer(tmp.path());
+
+    // Icon-only: "Papirus" — no cursors subdir.
+    fs::create_dir_all(user_data.join("icons/Papirus")).unwrap();
+    fs::create_dir_all(sys.join("icons/Papirus")).unwrap();
+
+    // Actual cursor: "Breeze" — has a cursors subdir in both locations.
+    fs::create_dir_all(user_data.join("icons/Breeze/cursors")).unwrap();
+    fs::create_dir_all(sys.join("icons/Breeze/cursors")).unwrap();
+
+    let shadowed = installer
+        .list_shadowed_resources(ResourceKind::Cursor)
+        .unwrap();
+    assert_eq!(shadowed.len(), 1, "only Breeze is a shadowed cursor");
+    assert_eq!(shadowed[0].name, "Breeze");
+}

--- a/crates/ui/src/app.rs
+++ b/crates/ui/src/app.rs
@@ -4,6 +4,7 @@
 //! Main application component — owns the AdwViewSwitcher navigation and
 //! top-level page switching.
 
+use crate::components::diagnostics::{DiagnosticsModel, DiagnosticsOutput};
 use crate::components::explore::{ExploreModel, ExploreOutput};
 use crate::components::installed::{InstalledModel, InstalledOutput};
 use crate::components::packs::{PacksModel, PacksOutput};
@@ -27,6 +28,8 @@ pub struct AppModel {
     settings: Controller<SettingsModel>,
     #[allow(dead_code)]
     shell_tweaks: Controller<ShellTweaksModel>,
+    #[allow(dead_code)]
+    diagnostics: Controller<DiagnosticsModel>,
     toast_overlay: adw::ToastOverlay,
 }
 
@@ -84,6 +87,12 @@ impl SimpleComponent for AppModel {
             .launch(services.clone())
             .detach();
 
+        let diagnostics = DiagnosticsModel::builder()
+            .launch(services.clone())
+            .forward(sender.input_sender(), |msg| match msg {
+                DiagnosticsOutput::Toast(s) => AppMsg::Toast(s),
+            });
+
         // Build the layout with ToastOverlay wrapping ToolbarView
         let toast_overlay = adw::ToastOverlay::new();
 
@@ -138,6 +147,12 @@ impl SimpleComponent for AppModel {
             "preferences-desktop-symbolic",
         );
         view_stack.add_titled_with_icon(
+            diagnostics.widget(),
+            Some("diagnostics"),
+            "Diagnostics",
+            "dialog-information-symbolic",
+        );
+        view_stack.add_titled_with_icon(
             settings.widget(),
             Some("settings"),
             "Settings",
@@ -151,6 +166,7 @@ impl SimpleComponent for AppModel {
             packs,
             settings,
             shell_tweaks,
+            diagnostics,
             toast_overlay: toast_overlay.clone(),
         };
 

--- a/crates/ui/src/components/diagnostics.rs
+++ b/crates/ui/src/components/diagnostics.rs
@@ -1,0 +1,369 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Diagnostics view — surfaces two classes of invisible-but-important
+//! system state:
+//!
+//! 1. **Shadowed resources** (GXF-012): a theme / icon / cursor
+//!    installed in more than one XDG search path. The freedesktop
+//!    lookup spec picks the first match; later copies are masked.
+//!    Users regularly report "my new theme isn't applying" when the
+//!    fresh user-local install is shadowed by an older system copy.
+//!    We list every such conflict so the user knows which location
+//!    is winning and can clean up the other.
+//!
+//! 2. **Window-decoration mix** (GXF-021): CSD vs SSD counts for
+//!    currently-open windows. Theme-builder controls (headerbar
+//!    height, window radius, drop-shadow) only reach client-side
+//!    decorated apps. Showing the mix explains why some apps (Slack,
+//!    Steam, Wine) stay visually unchanged.
+//!
+//! This view is **read-only**. We don't offer to delete shadowing
+//! copies or flip decoration modes — those actions need confirmation
+//! dialogs and elevated-privilege plumbing that belong in follow-up
+//! work. Users do the cleanup themselves with the information we
+//! surface.
+
+use crate::services::AppServices;
+use adw::prelude::*;
+use gnomex_app::ports::{LocalInstaller, WindowDecorationProbe};
+use gnomex_domain::{DecorationMode, DecorationReport, ResourceKind, ShadowedResource};
+use relm4::prelude::*;
+use std::sync::Arc;
+
+pub struct DiagnosticsModel {
+    installer: Arc<dyn LocalInstaller>,
+    decoration_probe: Arc<dyn WindowDecorationProbe>,
+    content_box: gtk::Box,
+}
+
+#[derive(Debug)]
+pub enum DiagnosticsMsg {
+    Refresh,
+}
+
+#[derive(Debug)]
+pub enum DiagnosticsOutput {
+    Toast(String),
+}
+
+#[relm4::component(pub)]
+impl SimpleComponent for DiagnosticsModel {
+    type Init = AppServices;
+    type Input = DiagnosticsMsg;
+    type Output = DiagnosticsOutput;
+
+    view! {
+        gtk::Box {
+            set_orientation: gtk::Orientation::Vertical,
+            set_vexpand: true,
+        }
+    }
+
+    fn init(
+        services: AppServices,
+        root: Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let scroll = gtk::ScrolledWindow::builder().vexpand(true).build();
+        let clamp = adw::Clamp::builder()
+            .maximum_size(720)
+            .margin_top(24)
+            .margin_bottom(24)
+            .margin_start(24)
+            .margin_end(24)
+            .build();
+        let content_box = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .spacing(24)
+            .build();
+
+        // Header with refresh button — diagnostics are a snapshot;
+        // re-probing on demand is cheap and expected.
+        let header_row = gtk::Box::builder()
+            .orientation(gtk::Orientation::Horizontal)
+            .spacing(12)
+            .build();
+        let title = gtk::Label::builder()
+            .label("Diagnostics")
+            .halign(gtk::Align::Start)
+            .hexpand(true)
+            .css_classes(["title-1"])
+            .build();
+        header_row.append(&title);
+        let refresh_btn = gtk::Button::builder()
+            .icon_name("view-refresh-symbolic")
+            .tooltip_text("Re-scan diagnostics")
+            .css_classes(["flat"])
+            .build();
+        {
+            let sender = sender.clone();
+            refresh_btn.connect_clicked(move |_| {
+                sender.input(DiagnosticsMsg::Refresh);
+            });
+        }
+        header_row.append(&refresh_btn);
+        content_box.append(&header_row);
+
+        let subtitle = gtk::Label::builder()
+            .label(
+                "These checks surface invisible conflicts \u{2014} shadowed theme copies on \
+                 your search path, and apps whose decorations the theme builder cannot \
+                 reach. Everything here is read-only.",
+            )
+            .wrap(true)
+            .halign(gtk::Align::Start)
+            .css_classes(["dim-label"])
+            .build();
+        content_box.append(&subtitle);
+
+        clamp.set_child(Some(&content_box));
+        scroll.set_child(Some(&clamp));
+        root.append(&scroll);
+
+        let model = DiagnosticsModel {
+            installer: services.installer.clone(),
+            decoration_probe: services.decoration_probe.clone(),
+            content_box: content_box.clone(),
+        };
+
+        let widgets = view_output!();
+        sender.input(DiagnosticsMsg::Refresh);
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, msg: DiagnosticsMsg, sender: ComponentSender<Self>) {
+        match msg {
+            DiagnosticsMsg::Refresh => {
+                // Remove everything after the subtitle (children 0 = header,
+                // 1 = subtitle). Rebuild the dynamic sections.
+                let keep_count = 2;
+                let mut seen = 0;
+                let mut to_remove = Vec::new();
+                let mut child = self.content_box.first_child();
+                while let Some(c) = child {
+                    let next = c.next_sibling();
+                    if seen >= keep_count {
+                        to_remove.push(c);
+                    }
+                    seen += 1;
+                    child = next;
+                }
+                for c in to_remove {
+                    self.content_box.remove(&c);
+                }
+
+                let themes = self
+                    .installer
+                    .list_shadowed_resources(ResourceKind::Theme)
+                    .unwrap_or_default();
+                let icons = self
+                    .installer
+                    .list_shadowed_resources(ResourceKind::Icon)
+                    .unwrap_or_default();
+                let cursors = self
+                    .installer
+                    .list_shadowed_resources(ResourceKind::Cursor)
+                    .unwrap_or_default();
+
+                let shadowed_group = build_shadowed_group(&themes, &icons, &cursors);
+                self.content_box.append(&shadowed_group);
+
+                let report = self.decoration_probe.detect_decoration_mix();
+                let decoration_group = build_decoration_group(&report);
+                self.content_box.append(&decoration_group);
+
+                let _ = sender.output(DiagnosticsOutput::Toast(format!(
+                    "Diagnostics refreshed: {} shadowed, {} windows",
+                    themes.len() + icons.len() + cursors.len(),
+                    report.windows.len(),
+                )));
+            }
+        }
+    }
+}
+
+fn build_shadowed_group(
+    themes: &[ShadowedResource],
+    icons: &[ShadowedResource],
+    cursors: &[ShadowedResource],
+) -> adw::PreferencesGroup {
+    let group = adw::PreferencesGroup::builder()
+        .title("Shadowed Resources")
+        .description(
+            "A theme / icon pack / cursor installed in more than one search path. \
+             Per the freedesktop spec GTK picks the first match \u{2014} the other \
+             copies are masked. If your new install isn\u{2019}t showing up, it\u{2019}s \
+             probably being shadowed by an older system copy.",
+        )
+        .build();
+
+    let total = themes.len() + icons.len() + cursors.len();
+    if total == 0 {
+        let empty = adw::ActionRow::builder()
+            .title("No shadowing detected")
+            .subtitle("Every installed theme, icon pack, and cursor exists in exactly one location.")
+            .css_classes(["success"])
+            .build();
+        let icon = gtk::Image::from_icon_name("emblem-ok-symbolic");
+        icon.add_css_class("success");
+        empty.add_prefix(&icon);
+        group.add(&empty);
+        return group;
+    }
+
+    for entry in themes.iter().chain(icons.iter()).chain(cursors.iter()) {
+        group.add(&build_shadowed_row(entry));
+    }
+    group
+}
+
+/// Build an expander row for one shadowed resource — title shows the
+/// resource kind + name, the winning location sits on the row itself,
+/// and every masked copy is exposed as a sub-row when the user opens
+/// the expander.
+fn build_shadowed_row(entry: &ShadowedResource) -> adw::ExpanderRow {
+    let winner = entry.winning_location();
+    let title = format!("{}: {}", entry.kind.label(), entry.name);
+    let subtitle = if entry.user_install_masked() {
+        format!(
+            "Winning: {} (system) \u{2014} your user install is masked",
+            winner.path.display()
+        )
+    } else {
+        format!(
+            "Winning: {} ({})",
+            winner.path.display(),
+            if winner.user_writable { "user" } else { "system" },
+        )
+    };
+    let row = adw::ExpanderRow::builder()
+        .title(title)
+        .subtitle(subtitle)
+        .build();
+
+    let css = if entry.user_install_masked() {
+        "warning"
+    } else {
+        "dim-label"
+    };
+    let icon = gtk::Image::from_icon_name(if entry.user_install_masked() {
+        "dialog-warning-symbolic"
+    } else {
+        "emblem-default-symbolic"
+    });
+    icon.add_css_class(css);
+    row.add_prefix(&icon);
+
+    // Winning row — repeated inside the expander so the user sees the
+    // full list when the row opens.
+    let winner_row = adw::ActionRow::builder()
+        .title(winner.path.display().to_string())
+        .subtitle(if winner.user_writable {
+            "User-writable \u{2014} this copy wins"
+        } else {
+            "System-wide \u{2014} this copy wins"
+        })
+        .css_classes(["property"])
+        .build();
+    let badge = gtk::Label::builder()
+        .label("Winning")
+        .css_classes(["success", "caption-heading"])
+        .valign(gtk::Align::Center)
+        .build();
+    winner_row.add_suffix(&badge);
+    row.add_row(&winner_row);
+
+    for loc in entry.masked_locations() {
+        let masked_row = adw::ActionRow::builder()
+            .title(loc.path.display().to_string())
+            .subtitle(if loc.user_writable {
+                "User-writable \u{2014} masked by earlier copy"
+            } else {
+                "System-wide \u{2014} masked by earlier copy"
+            })
+            .build();
+        let masked_badge = gtk::Label::builder()
+            .label("Masked")
+            .css_classes(["warning", "caption-heading"])
+            .valign(gtk::Align::Center)
+            .build();
+        masked_row.add_suffix(&masked_badge);
+        row.add_row(&masked_row);
+    }
+
+    row
+}
+
+fn build_decoration_group(report: &DecorationReport) -> adw::PreferencesGroup {
+    let total = report.windows.len();
+    let csd = report.csd_count();
+    let ssd = report.ssd_count();
+    let unknown = report.unknown_count();
+
+    let description = if total == 0 {
+        "No window information available. Install `wmctrl` for a detailed decoration \
+         breakdown, or open a few apps and refresh."
+            .to_string()
+    } else if ssd == 0 {
+        format!(
+            "All {total} open windows draw their own decorations (CSD). The theme \
+             builder reaches every visible app.",
+        )
+    } else {
+        format!(
+            "{csd} window(s) use client-side decorations (CSD) \u{2014} the theme \
+             builder reaches these. {ssd} use server-side decorations (SSD) and \
+             will not pick up headerbar styling or window radius. {unknown} \
+             could not be classified.",
+        )
+    };
+
+    let group = adw::PreferencesGroup::builder()
+        .title("Window Decorations")
+        .description(description)
+        .build();
+
+    if total == 0 {
+        return group;
+    }
+
+    // Stable order: SSD first (that's what the user cares about),
+    // then CSD, then Unknown; sort by class within each bucket.
+    let mut sorted: Vec<_> = report.windows.iter().collect();
+    sorted.sort_by(|a, b| {
+        let ak = mode_order(a.mode);
+        let bk = mode_order(b.mode);
+        ak.cmp(&bk).then_with(|| a.app_class.cmp(&b.app_class))
+    });
+
+    for win in sorted {
+        let row = adw::ActionRow::builder()
+            .title(win.app_class.clone())
+            .subtitle(win.title.clone().unwrap_or_default())
+            .build();
+        let badge = gtk::Label::builder()
+            .label(win.mode.label())
+            .css_classes([
+                match win.mode {
+                    DecorationMode::Csd => "success",
+                    DecorationMode::Ssd => "warning",
+                    DecorationMode::Unknown => "dim-label",
+                },
+                "caption-heading",
+            ])
+            .valign(gtk::Align::Center)
+            .build();
+        row.add_suffix(&badge);
+        group.add(&row);
+    }
+    group
+}
+
+fn mode_order(mode: DecorationMode) -> u8 {
+    match mode {
+        DecorationMode::Ssd => 0,
+        DecorationMode::Unknown => 1,
+        DecorationMode::Csd => 2,
+    }
+}

--- a/crates/ui/src/components/mod.rs
+++ b/crates/ui/src/components/mod.rs
@@ -4,6 +4,7 @@
 pub mod color_picker;
 pub mod content_row;
 pub mod detail_view;
+pub mod diagnostics;
 pub mod explore;
 pub mod extension_row;
 pub mod installed;

--- a/crates/ui/src/components/theme_builder.rs
+++ b/crates/ui/src/components/theme_builder.rs
@@ -273,6 +273,43 @@ impl SimpleComponent for ThemeBuilderModel {
             Some(g)
         };
 
+        // === SSD/CSD decoration banner (GXF-021) ===
+        // Snapshot the currently-open window mix at init. Theme-builder
+        // controls (headerbar height, window radius, CSD drop-shadow)
+        // only reach CSD apps; SSD apps render their titlebar via
+        // Mutter and stay visually unchanged. Surface a compact
+        // warning row whenever SSD windows are detected so users
+        // understand the coverage limits before tuning.
+        let decoration_report = services.decoration_probe.detect_decoration_mix();
+        let decoration_group = if decoration_report.has_ssd_windows() {
+            let ssd_list = decoration_report.ssd_app_classes().join(", ");
+            let g = adw::PreferencesGroup::builder()
+                .title("Some windows use server-side decorations")
+                .description(
+                    "The controls below apply to apps that draw their own \
+                     decorations (CSD). Apps listed here use SSD \u{2014} \
+                     their titlebar is drawn by the window manager and will \
+                     not pick up headerbar or window-radius changes. See \
+                     the Diagnostics tab for the full list.",
+                )
+                .build();
+            let row = adw::ActionRow::builder()
+                .title(format!(
+                    "{} SSD app(s) open",
+                    decoration_report.ssd_count(),
+                ))
+                .subtitle(ssd_list)
+                .css_classes(["warning"])
+                .build();
+            let icon = gtk::Image::from_icon_name("dialog-warning-symbolic");
+            icon.add_css_class("warning");
+            row.add_prefix(&icon);
+            g.add(&row);
+            Some(g)
+        } else {
+            None
+        };
+
         // === Unified Accent Color section ===
         // Dynamically shows single or day/night pickers based on schedule toggle.
         let accent_group = adw::PreferencesGroup::builder()
@@ -1875,6 +1912,9 @@ impl SimpleComponent for ThemeBuilderModel {
             .build();
         sidebar_box.append(&version_banner);
         if let Some(ref g) = conflicts_group {
+            sidebar_box.append(g);
+        }
+        if let Some(ref g) = decoration_group {
             sidebar_box.append(g);
         }
         sidebar_box.append(&sidebar_list);

--- a/crates/ui/src/services.rs
+++ b/crates/ui/src/services.rs
@@ -8,7 +8,8 @@
 //! every view can spawn async work on the tokio runtime.
 
 use gnomex_app::ports::{
-    BlurMyShellController, FloatingDockController, ShellCustomizer, ThemingConflictDetector,
+    BlurMyShellController, FloatingDockController, LocalInstaller, ShellCustomizer,
+    ThemingConflictDetector, WindowDecorationProbe,
 };
 use gnomex_app::use_cases::{
     ApplyThemeUseCase, BrowseUseCase, CustomizeShellUseCase, CustomizeUseCase, ManageUseCase,
@@ -17,7 +18,7 @@ use gnomex_app::use_cases::{
 use gnomex_infra::{
     ChromiumThemer, DbusShellProxy, EgoClient, FilesystemInstaller, FilesystemThemeWriter,
     GSettingsAppSettings, GSettingsAppearance, GSettingsBlurMyShell, GSettingsFloatingDock,
-    GioThemingConflictDetector, OcsClient, PackTomlStorage, VscodeThemer,
+    GioThemingConflictDetector, OcsClient, PackTomlStorage, VscodeThemer, WmctrlDecorationProbe,
 };
 use std::sync::Arc;
 use tokio::runtime::Handle;
@@ -35,6 +36,12 @@ pub struct AppServices {
     pub floating_dock: Arc<dyn FloatingDockController>,
     pub blur_my_shell: Arc<dyn BlurMyShellController>,
     pub conflict_detector: Arc<dyn ThemingConflictDetector>,
+    /// Direct handle to the local-install adapter — the diagnostics
+    /// view needs `list_shadowed_resources` which isn't exposed
+    /// through a use case.
+    pub installer: Arc<dyn LocalInstaller>,
+    /// CSD / SSD probe for the decoration-mix report.
+    pub decoration_probe: Arc<dyn WindowDecorationProbe>,
     pub detected_gnome_version: String,
 }
 
@@ -106,6 +113,11 @@ impl AppServices {
             &shell_version,
         ));
 
+        // Keep an `Arc<dyn LocalInstaller>` handle for the UI
+        // diagnostics view before the concrete `installer` is moved
+        // into `PacksUseCase`.
+        let installer_for_ui: Arc<dyn LocalInstaller> = installer.clone();
+
         let packs = Arc::new(PacksUseCase::new(
             pack_storage,
             appearance.clone(),
@@ -125,6 +137,9 @@ impl AppServices {
         let conflict_detector: Arc<dyn ThemingConflictDetector> =
             Arc::new(GioThemingConflictDetector::new());
 
+        let decoration_probe: Arc<dyn WindowDecorationProbe> =
+            Arc::new(WmctrlDecorationProbe::new());
+
         Self {
             handle,
             browse,
@@ -136,6 +151,8 @@ impl AppServices {
             floating_dock,
             blur_my_shell,
             conflict_detector,
+            installer: installer_for_ui,
+            decoration_probe,
             detected_gnome_version,
         }
     }


### PR DESCRIPTION
## Summary

Two diagnostic surfaces for invisible-but-load-bearing system state:

- **Shadowed resources (#7)** — new domain types (`ShadowedResource`, `ShadowedLocation`, `ResourceKind`) with `winning_location()` / `masked_locations()` / `user_install_masked()` helpers. `LocalInstaller::list_shadowed_resources(kind)` (new default-impl trait method). Concrete `FilesystemInstaller` impl reusing the existing `theme_paths::shadow_map` helper, plus a `with_paths(...)` constructor for hermetic tests.
- **SSD/CSD decoration probe (#9)** — new `DecorationMode` / `WindowDecorationInfo` / `DecorationReport` domain types, `WindowDecorationProbe` port, and `WmctrlDecorationProbe` infra adapter shelling out to `wmctrl -lx` and classifying by known CSD/SSD WM_CLASS substrings.

Both surfaces land in a new **Diagnostics** tab (`crates/ui/src/components/diagnostics.rs`). The Theme Builder sidebar also gets a banner — underneath the existing conflicts banner — when the probe detects SSD windows, naming the offending app classes and pointing the user at Diagnostics for the full list.

## Why

- The shadow helper from Batch 1 (GXF-010) has been in the codebase for weeks but was never surfaced. Users were reporting "I installed theme X but it's not picking up" and the answer was usually "an older system copy at `/usr/share/themes/` is shadowing your `~/.local/share/themes/` copy." Now they can see it.
- The theme-builder controls (headerbar height, window radius, CSD drop-shadow) only reach CSD apps. SSD apps — Electron without `WaylandWindowDecorations`, legacy GTK 3 dialogs, XWayland Wine/Proton, Qt without a GNOME platform theme — look unthemed no matter what. Surfacing the mix turns a debugging session into a glance.

## Scope trade-offs

- **Display-only shadow view.** Deletion UI deferred — confirmation + recovery plumbing aren't worth mixing in.
- **Heuristic probe.** `wmctrl -lx` + WM_CLASS substring matching is conservative. Missing `wmctrl` yields an empty report (no false banner). A pure-Wayland Shell-extension path is the real fix and is follow-up work.
- **Snapshot, not reactive.** Probe runs on Theme Builder open; the UI doesn't live-update as windows open/close.

## Test plan

- [x] `cargo test --workspace` passes (~170 tests).
- [x] New unit tests: `ShadowedResource` invariants, `DecorationReport` aggregation, probe classifier (CSD/SSD/Unknown), `wmctrl` output parser with malformed lines.
- [x] New hermetic integration test `crates/infra/tests/shadowed_resources.rs` — uses `ResourcePaths::explicit` + `FilesystemInstaller::with_paths` to build a fake XDG tree with zero `$HOME`/`$XDG_*` dependency.
- [x] Manually verify: drop a throwaway theme into `/usr/share/themes/Test/` AND `~/.local/share/themes/Test/`, open Diagnostics, confirm `Test` appears as shadowed with the system copy flagged as winning.
- [x] Manually verify: open an Electron app launched without `--ozone-platform=wayland`, confirm the SSD banner appears on the Theme Builder naming that app class.

Closes #7
Closes #9