### PR TITLE
fix: restore wallpaper colour extraction under slideshows + palette-index lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,10 +1102,12 @@ version = "0.2.0"
 name = "gnomex-infra"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "chrono",
  "directories",
  "flate2",
+ "gdk-pixbuf",
  "gio",
  "gnomex-app",
  "gnomex-domain",

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -19,11 +19,14 @@
 //! Architecture: pure composition of existing domain+app+infra crates.
 
 use anyhow::{Context, Result};
-use gdk_pixbuf::Pixbuf;
 use gio::prelude::*;
 use gnomex_app::ports::ExternalAppThemer;
 use gnomex_domain::{color, ColorScheme, ExternalThemeSpec, HexColor};
+use gnomex_infra::wallpaper_palette::{
+    encode_palette, extract_palette, locked_accent, resolve_wallpaper_image, PaletteEntry,
+};
 use gnomex_infra::{ChromiumThemer, VscodeThemer};
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -145,62 +148,197 @@ fn setup_accent_schedule_watcher(
 }
 
 /// Watch wallpaper changes. On every change we:
-///   1. extract the top-N palette (always) and cache to
-///      `cached-wallpaper-palette` so the UI can show swatches
-///      immediately without running its own extraction.
-///   2. if the user has `use-wallpaper-accent` enabled, also pick the
-///      dominant match and write it to `accent-color`.
+///   1. resolve the current image (handling slideshow `.xml`);
+///   2. extract the top-N palette (always) and cache it to
+///      `cached-wallpaper-palette` so the UI can paint swatches
+///      immediately without re-running extraction;
+///   3. if `use-wallpaper-accent` is enabled, write the accent —
+///      using `wallpaper-accent-index` to pick the locked swatch when
+///      the user previously clicked one, otherwise the dominant.
+///
+/// We also install a slideshow-interval tick: when `picture-uri`
+/// points to a GNOME slideshow `.xml`, GNOME cycles images internally
+/// *without* changing the GSetting, so `connect_changed` never fires.
+/// The tick re-resolves the current image on the slideshow's own
+/// cadence and reruns steps 2 and 3.
 fn setup_wallpaper_watcher() {
     let bg_settings = Rc::new(gio::Settings::new(BG_SCHEMA));
     let app_settings = Rc::new(gio::Settings::new(APP_SCHEMA));
 
-    let app_clone = app_settings.clone();
-    let bg_clone = bg_settings.clone();
-    bg_settings.clone().connect_changed(Some("picture-uri"), move |_, _| {
-        let uri = bg_clone.string("picture-uri").to_string();
-        let Some(path) = uri.strip_prefix("file://") else {
-            return;
-        };
-        tracing::info!("wallpaper changed: {uri}");
+    // Track the current slideshow tick so we can replace it when the
+    // wallpaper (or interval) changes.
+    let slideshow_tick: Rc<RefCell<Option<glib::SourceId>>> =
+        Rc::new(RefCell::new(None));
 
-        // --- Always: extract palette and cache it. ---
-        match extract_wallpaper_palette(path) {
-            Ok(palette) if !palette.is_empty() => {
-                // GSettings 'as' array — one entry per (hex, accent_id)
-                // pair, delimited with ':' so UI can parse cheaply.
-                let encoded: Vec<String> = palette
-                    .iter()
-                    .map(|(hex, id)| format!("{hex}:{id}"))
-                    .collect();
+    // One code-path for "wallpaper is different now — re-extract and
+    // maybe re-apply". Called from both the `picture-uri` watcher and
+    // the slideshow tick.
+    let reapply = {
+        let bg = bg_settings.clone();
+        let app = app_settings.clone();
+        Rc::new(move |reason: &str| {
+            let uri = bg.string("picture-uri").to_string();
+            let Some(image) = resolve_image(&uri) else {
+                tracing::warn!("could not resolve wallpaper image for {uri}");
+                return;
+            };
+            tracing::debug!("wallpaper re-extract ({reason}): {}", image.display());
+
+            let palette = match extract_palette(&image) {
+                Ok(p) if !p.is_empty() => p,
+                Ok(_) => {
+                    tracing::warn!("no dominant colours in {}", image.display());
+                    Vec::new()
+                }
+                Err(e) => {
+                    tracing::warn!("extraction failed for {}: {e}", image.display());
+                    return;
+                }
+            };
+
+            if !palette.is_empty() {
+                let encoded = encode_palette(&palette);
                 let refs: Vec<&str> = encoded.iter().map(String::as_str).collect();
-                let _ = app_clone.set_strv("cached-wallpaper-palette", refs);
+                let _ = app.set_strv("cached-wallpaper-palette", refs);
                 tracing::info!(
-                    "cached wallpaper palette: {} colors",
-                    palette.len()
+                    "cached wallpaper palette: {} colours from {}",
+                    palette.len(),
+                    image.display(),
                 );
             }
-            Ok(_) => tracing::warn!("no dominant colors extracted from wallpaper"),
-            Err(e) => tracing::warn!("wallpaper extraction failed: {e}"),
-        }
 
-        // --- Opt-in: also set the accent color. ---
-        let wants_reactive = app_clone
-            .settings_schema()
-            .map(|s| s.has_key("use-wallpaper-accent"))
-            .unwrap_or(false)
-            && app_clone.boolean("use-wallpaper-accent");
-        if wants_reactive {
-            match extract_dominant_accent(path) {
-                Ok(Some(accent_id)) => {
-                    let iface = gio::Settings::new(IFACE_SCHEMA);
-                    let _ = iface.set_string("accent-color", &accent_id);
-                    tracing::info!("auto-accent from wallpaper → {accent_id}");
-                }
-                Ok(None) => tracing::warn!("no dominant color extracted from wallpaper"),
-                Err(e) => tracing::warn!("accent extraction failed: {e}"),
+            let wants_reactive = app
+                .settings_schema()
+                .map(|s| s.has_key("use-wallpaper-accent"))
+                .unwrap_or(false)
+                && app.boolean("use-wallpaper-accent");
+            if wants_reactive {
+                apply_accent_from_palette(&app, &palette);
             }
+        })
+    };
+
+    // --- picture-uri change (user picked a new wallpaper or slideshow XML) ---
+    {
+        let bg = bg_settings.clone();
+        let app = app_settings.clone();
+        let slideshow_tick = slideshow_tick.clone();
+        let reapply = reapply.clone();
+        bg_settings
+            .clone()
+            .connect_changed(Some("picture-uri"), move |_, _| {
+                let uri = bg.string("picture-uri").to_string();
+                tracing::info!("wallpaper changed: {uri}");
+                reapply("picture-uri changed");
+                reinstall_slideshow_tick(&uri, &app, &slideshow_tick, reapply.clone());
+            });
+    }
+
+    // --- wallpaper-accent-index change: re-evaluate immediately so
+    //     the user's click takes effect without having to also touch
+    //     the wallpaper. ---
+    {
+        let reapply = reapply.clone();
+        app_settings
+            .clone()
+            .connect_changed(Some("wallpaper-accent-index"), move |_, _| {
+                reapply("wallpaper-accent-index changed");
+            });
+    }
+
+    // --- slideshow-interval change: rebuild the tick so cycles line
+    //     up with the fresh interval. ---
+    {
+        let bg = bg_settings.clone();
+        let app = app_settings.clone();
+        let slideshow_tick = slideshow_tick.clone();
+        let reapply = reapply.clone();
+        app_settings
+            .clone()
+            .connect_changed(Some("wallpaper-slideshow-interval"), move |_, _| {
+                let uri = bg.string("picture-uri").to_string();
+                reinstall_slideshow_tick(&uri, &app, &slideshow_tick, reapply.clone());
+            });
+    }
+
+    // --- On startup, prime the palette + tick using the current URI. ---
+    {
+        let uri = bg_settings.string("picture-uri").to_string();
+        reapply("startup");
+        reinstall_slideshow_tick(
+            &uri,
+            &app_settings,
+            &slideshow_tick,
+            reapply.clone(),
+        );
+    }
+}
+
+/// Resolve the current wallpaper image, whether `raw` is a plain image
+/// URI or a slideshow `.xml`.
+fn resolve_image(raw: &str) -> Option<std::path::PathBuf> {
+    match resolve_wallpaper_image(raw) {
+        Ok(Some(p)) => Some(p),
+        Ok(None) => None,
+        Err(e) => {
+            tracing::warn!("wallpaper resolve failed for {raw}: {e}");
+            None
         }
+    }
+}
+
+/// Write the accent color from `palette` to GNOME's `accent-color`,
+/// respecting the `wallpaper-accent-index` lock if it's set to a valid
+/// index. Silently no-ops on an empty palette.
+fn apply_accent_from_palette(app: &gio::Settings, palette: &[PaletteEntry]) {
+    let has_idx_key = app
+        .settings_schema()
+        .map(|s| s.has_key("wallpaper-accent-index"))
+        .unwrap_or(false);
+    let idx = if has_idx_key { app.int("wallpaper-accent-index") } else { -1 };
+
+    let Some(chosen) = locked_accent(palette, idx) else {
+        return;
+    };
+    let iface = gio::Settings::new(IFACE_SCHEMA);
+    if iface.string("accent-color").as_str() != chosen {
+        let _ = iface.set_string("accent-color", chosen);
+        let source = if idx >= 0 { format!("locked[{idx}]") } else { "dominant".into() };
+        tracing::info!("auto-accent from wallpaper ({source}) → {chosen}");
+    }
+}
+
+/// Remove any previously-installed slideshow tick, and — if the
+/// wallpaper URI points to a `.xml` — install a new one whose period
+/// is the user's `wallpaper-slideshow-interval` (floored to 5 s so a
+/// zero default can't wedge the daemon in a busy loop).
+fn reinstall_slideshow_tick(
+    uri: &str,
+    app: &gio::Settings,
+    slot: &Rc<RefCell<Option<glib::SourceId>>>,
+    reapply: Rc<dyn Fn(&str)>,
+) {
+    if let Some(old) = slot.borrow_mut().take() {
+        old.remove();
+    }
+
+    let is_slideshow = uri.strip_prefix("file://").unwrap_or(uri).ends_with(".xml");
+    if !is_slideshow {
+        return;
+    }
+
+    // Clamp to a safe minimum. GNOME's shortest stock slideshow is 1 s
+    // but we don't need to re-extract colours at that cadence; we re-
+    // sample at the configured hold time, which is the human-meaningful
+    // unit users actually see on screen.
+    let interval = app.uint("wallpaper-slideshow-interval").max(30);
+    tracing::info!("slideshow tick installed: every {interval}s");
+
+    let id = glib::timeout_add_seconds_local(interval, move || {
+        reapply("slideshow tick");
+        glib::ControlFlow::Continue
     });
+    *slot.borrow_mut() = Some(id);
 }
 
 /// Watch dark/light color scheme changes and re-apply external-app theming
@@ -346,123 +484,3 @@ fn nearest_accent_id(value: &str) -> String {
     best.to_owned()
 }
 
-/// Extract the dominant color from a wallpaper image and map it to the
-/// closest GNOME accent color id. Reuses the domain `color` module.
-fn extract_dominant_accent(path: &str) -> Result<Option<String>> {
-    let pixbuf = Pixbuf::from_file_at_scale(path, 64, 64, true)
-        .context("failed to load wallpaper image")?;
-    let Some(pixels) = pixbuf.pixel_bytes() else {
-        return Ok(None);
-    };
-    let channels = pixbuf.n_channels() as usize;
-    let data = pixels.as_ref();
-
-    let mut color_buckets: std::collections::HashMap<(u16, u8, u8), u32> =
-        std::collections::HashMap::new();
-
-    for chunk in data.chunks_exact(channels) {
-        if channels < 3 {
-            continue;
-        }
-        let (r, g, b) = (chunk[0], chunk[1], chunk[2]);
-        let (h, s, v) = color::rgb_to_hsv(r, g, b);
-        if s < 15 || v < 25 || v > 240 {
-            continue;
-        }
-        let hue_bin = (h / 10) * 10;
-        let sat_bin = (s / 85).min(2);
-        let val_bin = (v / 85).min(2);
-        *color_buckets.entry((hue_bin, sat_bin, val_bin)).or_default() += 1;
-    }
-
-    let Some(((hue_bin, sat_bin, val_bin), _)) =
-        color_buckets.into_iter().max_by_key(|(_, c)| *c)
-    else {
-        return Ok(None);
-    };
-
-    let h = hue_bin + 5;
-    let s = (sat_bin as u16) * 85 + 42;
-    let v = (val_bin as u16) * 85 + 42;
-    let (r, g, b) = color::hsv_to_rgb(h, s.min(255) as u8, v.min(255) as u8);
-
-    // Closest GNOME accent
-    let mut best_id = "blue";
-    let mut best_dist = u32::MAX;
-    for &(id, hex) in ACCENT_COLORS {
-        let accent = HexColor::new(hex).map(|c| c.to_rgb()).unwrap_or((0, 0, 0));
-        let dist = color::color_distance((r, g, b), accent);
-        if dist < best_dist {
-            best_dist = dist;
-            best_id = id;
-        }
-    }
-    Ok(Some(best_id.to_owned()))
-}
-
-/// Extract up to N distinct accent-mapped colors from a wallpaper image.
-/// Returns `(hex, accent_id)` pairs ordered by dominance. Duplicates by
-/// accent id are filtered so the user's swatches span distinct hues.
-fn extract_wallpaper_palette(path: &str) -> Result<Vec<(String, String)>> {
-    const MAX_COLORS: usize = 5;
-
-    let pixbuf = Pixbuf::from_file_at_scale(path, 64, 64, true)
-        .context("failed to load wallpaper image")?;
-    let Some(pixels) = pixbuf.pixel_bytes() else {
-        return Ok(Vec::new());
-    };
-    let channels = pixbuf.n_channels() as usize;
-    let data = pixels.as_ref();
-
-    let mut color_buckets: std::collections::HashMap<(u16, u8, u8), u32> =
-        std::collections::HashMap::new();
-
-    for chunk in data.chunks_exact(channels) {
-        if channels < 3 {
-            continue;
-        }
-        let (r, g, b) = (chunk[0], chunk[1], chunk[2]);
-        let (h, s, v) = color::rgb_to_hsv(r, g, b);
-        if s < 15 || v < 25 || v > 240 {
-            continue;
-        }
-        let hue_bin = (h / 10) * 10;
-        let sat_bin = (s / 85).min(2);
-        let val_bin = (v / 85).min(2);
-        *color_buckets.entry((hue_bin, sat_bin, val_bin)).or_default() += 1;
-    }
-
-    let mut buckets: Vec<_> = color_buckets.into_iter().collect();
-    buckets.sort_by(|a, b| b.1.cmp(&a.1));
-
-    let mut results = Vec::with_capacity(MAX_COLORS);
-    let mut used_accents = std::collections::HashSet::new();
-    for ((hue_bin, sat_bin, val_bin), _) in buckets.iter().take(20) {
-        let h = *hue_bin + 5;
-        let s = (*sat_bin as u16) * 85 + 42;
-        let v = (*val_bin as u16) * 85 + 42;
-        let (r, g, b) = color::hsv_to_rgb(h, s.min(255) as u8, v.min(255) as u8);
-
-        // Map to closest GNOME accent; skip if we've already taken a
-        // color mapped to this accent (keeps swatches visually distinct).
-        let mut best_id = "blue";
-        let mut best_dist = u32::MAX;
-        for &(id, hex) in ACCENT_COLORS {
-            let a = HexColor::new(hex).map(|c| c.to_rgb()).unwrap_or((0, 0, 0));
-            let d = color::color_distance((r, g, b), a);
-            if d < best_dist {
-                best_dist = d;
-                best_id = id;
-            }
-        }
-        if used_accents.contains(best_id) {
-            continue;
-        }
-        used_accents.insert(best_id.to_owned());
-        results.push((format!("#{r:02x}{g:02x}{b:02x}"), best_id.to_owned()));
-        if results.len() >= MAX_COLORS {
-            break;
-        }
-    }
-    Ok(results)
-}

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -25,6 +25,8 @@ zip = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 gio = { workspace = true }
+gdk-pixbuf = { workspace = true }
+anyhow = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 directories = { workspace = true }

--- a/crates/infra/src/lib.rs
+++ b/crates/infra/src/lib.rs
@@ -28,6 +28,7 @@ pub mod theme_paths;
 mod theme_writer;
 mod theming_conflict_detector;
 mod vscode_themer;
+pub mod wallpaper_palette;
 pub mod wallpaper_slideshow_xml;
 pub mod window_decoration_probe;
 

--- a/crates/infra/src/wallpaper_palette.rs
+++ b/crates/infra/src/wallpaper_palette.rs
@@ -1,0 +1,426 @@
+// Copyright 2026 GNOME X Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Wallpaper palette extraction — shared between the daemon and the UI.
+//!
+//! Handles two wallpaper shapes:
+//!
+//! - A single image file (jpg / png / webp / ...) — loaded directly.
+//! - A GNOME slideshow XML (`<background>` with `<static>`/`<transition>`
+//!   children) — we pick the picture that's *currently* showing based on
+//!   wall-clock time and extract from that.
+//!
+//! Before this module landed, both the `experienced` daemon and the
+//! Theme Builder UI had their own near-identical extractor that called
+//! `Pixbuf::from_file_at_scale` straight on `picture-uri`. When the
+//! wallpaper slideshow feature (GXF-072) started writing `.xml` files
+//! into `picture-uri`, both extractors failed silently because pixbuf
+//! cannot parse XML. This module is the single place that knows about
+//! both shapes.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use gdk_pixbuf::Pixbuf;
+use gnomex_domain::{color, HexColor};
+
+/// GNOME accent-color id / hex swatch pairs. The *ids* are what we
+/// write back into `org.gnome.desktop.interface accent-color`.
+pub const ACCENT_COLORS: &[(&str, &str)] = &[
+    ("blue", "#3584e4"),
+    ("teal", "#2190a4"),
+    ("green", "#3a944a"),
+    ("yellow", "#c88800"),
+    ("orange", "#ed5b00"),
+    ("red", "#e62d42"),
+    ("pink", "#d56199"),
+    ("purple", "#9141ac"),
+    ("slate", "#6f8396"),
+];
+
+/// Maximum palette entries returned by [`extract_palette`].
+pub const MAX_PALETTE: usize = 5;
+
+/// Resolve a value that the user gave us — a `file://` URI, a bare
+/// absolute path, or a slideshow XML path — into the concrete image
+/// file we should sample pixels from *right now*.
+///
+/// Returns `Ok(Some(path))` when an image was located, `Ok(None)` when
+/// the path is a slideshow XML that has no `<static>` entry we can
+/// resolve, and `Err` on IO failure (but NOT when the XML simply isn't
+/// a slideshow — that degrades to "treat the path as an image").
+pub fn resolve_wallpaper_image(raw: &str) -> Result<Option<PathBuf>> {
+    let bare = raw.strip_prefix("file://").unwrap_or(raw);
+    let path = Path::new(bare);
+    if path.extension().and_then(|s| s.to_str()) != Some("xml") {
+        return Ok(Some(path.to_path_buf()));
+    }
+
+    let xml = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => return Err(e).with_context(|| format!("read slideshow XML: {bare}")),
+    };
+    Ok(current_slideshow_image(&xml, path.parent(), now_unix()))
+}
+
+/// Pick the slideshow entry that should be showing at `now_epoch`
+/// (seconds since Unix epoch) for a slideshow XML whose content is
+/// `xml`. `relative_to` is the slideshow file's parent directory, used
+/// to resolve relative `<file>` paths.
+///
+/// Returns the absolute path of the currently-active image, or `None`
+/// if the XML has no `<static>` entries at all.
+///
+/// The algorithm:
+/// 1. Parse all `<static><duration><file>` entries in document order.
+/// 2. Ignore `<starttime>` — GNOME respects it for exact phase, but for
+///    a colour extractor it's enough to pick the entry at `now % sum`
+///    since the dominant hues stabilise across a cycle.
+/// 3. Project `now_epoch` onto the total loop length; walk the static
+///    entries until we land inside one.
+///
+/// This does *not* try to honour `<transition>` — during a transition
+/// GNOME is cross-fading, but both endpoints are already in the
+/// `<static>` list we'll sample, and the crossfade window is much
+/// shorter than the static hold.
+pub fn current_slideshow_image(
+    xml: &str,
+    relative_to: Option<&Path>,
+    now_epoch: u64,
+) -> Option<PathBuf> {
+    let statics = parse_static_entries(xml);
+    if statics.is_empty() {
+        return None;
+    }
+    let total: f64 = statics.iter().map(|(d, _)| d.max(0.0)).sum();
+    if total <= 0.0 {
+        return statics.into_iter().next().map(|(_, p)| resolve_rel(relative_to, p));
+    }
+
+    let phase = (now_epoch as f64) % total;
+    let mut acc = 0.0f64;
+    for (dur, file) in statics {
+        let seg = dur.max(0.0);
+        if phase < acc + seg {
+            return Some(resolve_rel(relative_to, file));
+        }
+        acc += seg;
+    }
+    // Floating-point rounding edge — fall back to the last entry.
+    None
+}
+
+fn resolve_rel(relative_to: Option<&Path>, file: String) -> PathBuf {
+    let p = Path::new(&file);
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else if let Some(base) = relative_to {
+        base.join(p)
+    } else {
+        p.to_path_buf()
+    }
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Cheap `<static>` parser — returns `(duration_seconds, file)` tuples
+/// in document order. The slideshow format is small enough that a
+/// dedicated parser dependency would be overkill; this walks tag pairs
+/// by hand. Case-sensitive (GNOME writes them lowercase).
+fn parse_static_entries(xml: &str) -> Vec<(f64, String)> {
+    let mut out = Vec::new();
+    let mut rest = xml;
+    while let Some(start) = rest.find("<static>") {
+        let after = &rest[start + "<static>".len()..];
+        let Some(end) = after.find("</static>") else {
+            break;
+        };
+        let body = &after[..end];
+
+        let duration = extract_tag(body, "duration")
+            .and_then(|s| s.trim().parse::<f64>().ok())
+            .unwrap_or(0.0);
+        if let Some(file) = extract_tag(body, "file") {
+            let file = xml_unescape(file.trim());
+            out.push((duration, file));
+        }
+
+        rest = &after[end + "</static>".len()..];
+    }
+    out
+}
+
+fn extract_tag<'a>(body: &'a str, tag: &str) -> Option<&'a str> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let i = body.find(&open)?;
+    let after = &body[i + open.len()..];
+    let j = after.find(&close)?;
+    Some(&after[..j])
+}
+
+fn xml_unescape(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&apos;", "'")
+        .replace("&quot;", "\"")
+}
+
+/// A single palette entry: a candidate hex plus the nearest GNOME
+/// accent id it was mapped to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaletteEntry {
+    pub hex: String,
+    pub accent_id: String,
+}
+
+/// Extract up to [`MAX_PALETTE`] distinct candidate colours from
+/// `image_path`. Returns empty if the image loads but has no
+/// sufficiently-saturated pixels.
+pub fn extract_palette(image_path: &Path) -> Result<Vec<PaletteEntry>> {
+    let pixbuf = Pixbuf::from_file_at_scale(
+        image_path.to_str().context("non-utf8 image path")?,
+        64,
+        64,
+        true,
+    )
+    .with_context(|| format!("load wallpaper image: {}", image_path.display()))?;
+    let Some(pixels) = pixbuf.pixel_bytes() else {
+        return Ok(Vec::new());
+    };
+    let channels = pixbuf.n_channels() as usize;
+    let data = pixels.as_ref();
+
+    let mut buckets: std::collections::HashMap<(u16, u8, u8), u32> = std::collections::HashMap::new();
+    for chunk in data.chunks_exact(channels) {
+        if channels < 3 {
+            continue;
+        }
+        let (r, g, b) = (chunk[0], chunk[1], chunk[2]);
+        let (h, s, v) = color::rgb_to_hsv(r, g, b);
+        if s < 15 || v < 25 || v > 240 {
+            continue;
+        }
+        let hue_bin = (h / 10) * 10;
+        let sat_bin = (s / 85).min(2);
+        let val_bin = (v / 85).min(2);
+        *buckets.entry((hue_bin, sat_bin, val_bin)).or_default() += 1;
+    }
+
+    let mut sorted: Vec<_> = buckets.into_iter().collect();
+    sorted.sort_by(|a, b| b.1.cmp(&a.1));
+
+    let mut results: Vec<PaletteEntry> = Vec::with_capacity(MAX_PALETTE);
+    let mut seen_accents: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for ((hue_bin, sat_bin, val_bin), _) in sorted.iter().take(20) {
+        let h = *hue_bin + 5;
+        let s = (*sat_bin as u16) * 85 + 42;
+        let v = (*val_bin as u16) * 85 + 42;
+        let (r, g, b) = color::hsv_to_rgb(h, s.min(255) as u8, v.min(255) as u8);
+        let accent_id = closest_accent_id(r, g, b);
+        if seen_accents.contains(&accent_id) {
+            continue;
+        }
+        seen_accents.insert(accent_id.clone());
+        results.push(PaletteEntry {
+            hex: format!("#{r:02x}{g:02x}{b:02x}"),
+            accent_id,
+        });
+        if results.len() >= MAX_PALETTE {
+            break;
+        }
+    }
+    Ok(results)
+}
+
+/// Nearest GNOME accent id for an (r, g, b) triple.
+pub fn closest_accent_id(r: u8, g: u8, b: u8) -> String {
+    let mut best = "blue";
+    let mut best_dist = u32::MAX;
+    for &(id, hex) in ACCENT_COLORS {
+        let accent = HexColor::new(hex).map(|c| c.to_rgb()).unwrap_or((0, 0, 0));
+        let dist = color::color_distance((r, g, b), accent);
+        if dist < best_dist {
+            best_dist = dist;
+            best = id;
+        }
+    }
+    best.to_owned()
+}
+
+/// Pick the accent id from `palette` that the user has locked to, or
+/// fall back to the dominant (index 0) when the lock is `-1` or the
+/// palette has fewer entries than the lock. Returns `None` when the
+/// palette is empty.
+///
+/// This is the core of the "remember which swatch the user picked"
+/// behaviour — see `wallpaper-accent-index` in the GSettings schema.
+pub fn locked_accent(palette: &[PaletteEntry], locked_index: i32) -> Option<&str> {
+    if palette.is_empty() {
+        return None;
+    }
+    let idx = if locked_index >= 0 && (locked_index as usize) < palette.len() {
+        locked_index as usize
+    } else {
+        0
+    };
+    Some(&palette[idx].accent_id)
+}
+
+/// Encode a palette for storage in the `cached-wallpaper-palette`
+/// strv GSetting. Each entry is `"HEX:ACCENT_ID"`.
+pub fn encode_palette(palette: &[PaletteEntry]) -> Vec<String> {
+    palette
+        .iter()
+        .map(|p| format!("{}:{}", p.hex, p.accent_id))
+        .collect()
+}
+
+/// Parse the `cached-wallpaper-palette` strv back into structured form.
+/// Silently drops malformed entries.
+pub fn decode_palette<S: AsRef<str>>(entries: &[S]) -> Vec<PaletteEntry> {
+    entries
+        .iter()
+        .filter_map(|e| {
+            let (hex, accent) = e.as_ref().split_once(':')?;
+            if hex.is_empty() || accent.is_empty() {
+                None
+            } else {
+                Some(PaletteEntry {
+                    hex: hex.to_owned(),
+                    accent_id: accent.to_owned(),
+                })
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated by GNOME X -->
+<background>
+  <starttime>
+    <year>2026</year><month>1</month><day>1</day>
+    <hour>0</hour><minute>0</minute><second>0</second>
+  </starttime>
+  <static><duration>10.0</duration><file>/abs/a.jpg</file></static>
+  <transition type="overlay"><duration>1.0</duration><from>/abs/a.jpg</from><to>/abs/b.jpg</to></transition>
+  <static><duration>10.0</duration><file>/abs/b.jpg</file></static>
+  <transition type="overlay"><duration>1.0</duration><from>/abs/b.jpg</from><to>/abs/a.jpg</to></transition>
+</background>
+"#;
+
+    #[test]
+    fn parse_extracts_both_statics() {
+        let statics = parse_static_entries(SAMPLE_XML);
+        assert_eq!(statics.len(), 2);
+        assert_eq!(statics[0].0, 10.0);
+        assert_eq!(statics[0].1, "/abs/a.jpg");
+        assert_eq!(statics[1].1, "/abs/b.jpg");
+    }
+
+    #[test]
+    fn current_image_picks_first_at_t_equals_zero() {
+        let got = current_slideshow_image(SAMPLE_XML, None, 0).unwrap();
+        assert_eq!(got, Path::new("/abs/a.jpg"));
+    }
+
+    #[test]
+    fn current_image_wraps_modulo_total_duration() {
+        // Total cycle ~ 20s (the 1s transitions are ignored by the
+        // static walker — they're crossfades, not holds). At t=12s
+        // we're inside the SECOND static (a=0..10, b=10..20).
+        let got = current_slideshow_image(SAMPLE_XML, None, 12).unwrap();
+        assert_eq!(got, Path::new("/abs/b.jpg"));
+
+        // At t=22s = 2 into next cycle → back to first.
+        let got = current_slideshow_image(SAMPLE_XML, None, 22).unwrap();
+        assert_eq!(got, Path::new("/abs/a.jpg"));
+    }
+
+    #[test]
+    fn relative_file_resolves_against_base() {
+        let xml = r#"<background>
+            <static><duration>5.0</duration><file>rel.jpg</file></static>
+        </background>"#;
+        let got = current_slideshow_image(xml, Some(Path::new("/base/dir")), 0).unwrap();
+        assert_eq!(got, Path::new("/base/dir/rel.jpg"));
+    }
+
+    #[test]
+    fn xml_unescape_handles_ampersand_and_quotes() {
+        assert_eq!(
+            xml_unescape("cats &amp; dogs &quot;rock&quot;"),
+            "cats & dogs \"rock\"",
+        );
+    }
+
+    #[test]
+    fn resolve_non_xml_path_returns_path_unchanged() {
+        let got = resolve_wallpaper_image("file:///abs/pic.jpg").unwrap().unwrap();
+        assert_eq!(got, Path::new("/abs/pic.jpg"));
+        let got = resolve_wallpaper_image("/abs/pic.png").unwrap().unwrap();
+        assert_eq!(got, Path::new("/abs/pic.png"));
+    }
+
+    #[test]
+    fn palette_encode_decode_roundtrip() {
+        let p = vec![
+            PaletteEntry { hex: "#ff0000".into(), accent_id: "red".into() },
+            PaletteEntry { hex: "#3584e4".into(), accent_id: "blue".into() },
+        ];
+        let encoded = encode_palette(&p);
+        let decoded = decode_palette(&encoded);
+        assert_eq!(decoded, p);
+    }
+
+    #[test]
+    fn locked_accent_respects_index_when_in_range() {
+        let p = vec![
+            PaletteEntry { hex: "#ff0000".into(), accent_id: "red".into() },
+            PaletteEntry { hex: "#00ff00".into(), accent_id: "green".into() },
+            PaletteEntry { hex: "#0000ff".into(), accent_id: "blue".into() },
+        ];
+        assert_eq!(locked_accent(&p, 1), Some("green"));
+        assert_eq!(locked_accent(&p, 2), Some("blue"));
+    }
+
+    #[test]
+    fn locked_accent_falls_back_to_dominant_when_unlocked_or_oob() {
+        let p = vec![
+            PaletteEntry { hex: "#ff0000".into(), accent_id: "red".into() },
+            PaletteEntry { hex: "#00ff00".into(), accent_id: "green".into() },
+        ];
+        // -1 = "no lock" → dominant.
+        assert_eq!(locked_accent(&p, -1), Some("red"));
+        // Out-of-range (user locked to a 5-colour palette, new wallpaper
+        // only yielded 2) → dominant.
+        assert_eq!(locked_accent(&p, 4), Some("red"));
+    }
+
+    #[test]
+    fn locked_accent_empty_palette_is_none() {
+        assert_eq!(locked_accent(&[], 0), None);
+        assert_eq!(locked_accent(&[], -1), None);
+    }
+
+    #[test]
+    fn decode_silently_drops_malformed_entries() {
+        let raw: Vec<String> = vec!["ok:blue".into(), "broken".into(), ":missing".into(), "also:ok".into()];
+        let decoded = decode_palette(&raw);
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(decoded[0].accent_id, "blue");
+        assert_eq!(decoded[1].hex, "also");
+    }
+}

--- a/crates/ui/src/components/theme_builder.rs
+++ b/crates/ui/src/components/theme_builder.rs
@@ -2242,6 +2242,19 @@ impl SimpleComponent for ThemeBuilderModel {
                     Ok(_) => tracing::info!("accent color set to: {color}"),
                     Err(e) => tracing::warn!("failed to set accent color: {e}"),
                 }
+                // Clear the wallpaper-palette lock — the stock accent
+                // button / manual pick is an explicit override of the
+                // wallpaper-driven choice. The daemon treats -1 as
+                // "use the dominant on the next wallpaper change".
+                let app = gio::Settings::new("io.github.gnomex.GnomeX");
+                if app
+                    .settings_schema()
+                    .map(|s| s.has_key("wallpaper-accent-index"))
+                    .unwrap_or(false)
+                    && app.int("wallpaper-accent-index") != -1
+                {
+                    let _ = app.set_int("wallpaper-accent-index", -1);
+                }
             }
             ThemeBuilderMsg::ExtractFromWallpaper => {
                 let bg = gio::Settings::new("org.gnome.desktop.background");
@@ -2252,13 +2265,28 @@ impl SimpleComponent for ThemeBuilderModel {
                     .to_owned();
 
                 let sender = sender.input_sender().clone();
-                // Run extraction off the main thread since it loads an image
+                // Run extraction off the main thread since it loads an
+                // image — and when the URI is a slideshow XML the
+                // shared helper also parses the XML to resolve the
+                // currently-active still.
                 std::thread::spawn(move || {
-                    match extract_wallpaper_colors(&path) {
-                        Ok(colors) => sender.emit(ThemeBuilderMsg::WallpaperColorsReady(colors)),
-                        Err(e) => {
-                            tracing::warn!("wallpaper extraction failed: {e}");
+                    match gnomex_infra::wallpaper_palette::resolve_wallpaper_image(&path) {
+                        Ok(Some(image)) => {
+                            match gnomex_infra::wallpaper_palette::extract_palette(&image) {
+                                Ok(entries) => {
+                                    let colors: Vec<(String, String)> = entries
+                                        .into_iter()
+                                        .map(|e| (e.hex, e.accent_id))
+                                        .collect();
+                                    sender.emit(ThemeBuilderMsg::WallpaperColorsReady(colors));
+                                }
+                                Err(e) => tracing::warn!("wallpaper extraction failed: {e}"),
+                            }
                         }
+                        Ok(None) => {
+                            tracing::warn!("slideshow XML had no current picture entry");
+                        }
+                        Err(e) => tracing::warn!("resolve wallpaper URI failed: {e}"),
                     }
                 });
             }
@@ -2325,16 +2353,35 @@ impl SimpleComponent for ThemeBuilderModel {
                             }
                         }
 
-                        let sender = sender.clone();
                         let aid = accent_id.clone();
                         let pickers = pickers.clone();
+                        let swatch_index = i as i32;
                         btn.connect_toggled(move |b| {
                             if b.is_active() {
                                 // Deselect all color picker toggles
                                 for picker in &pickers {
                                     color_picker::deselect_all(picker);
                                 }
-                                sender.input(ThemeBuilderMsg::SetAccentColor(aid.clone()));
+                                // Persist the palette INDEX the user
+                                // picked, so the daemon can re-apply
+                                // the same slot when the wallpaper
+                                // changes. We write accent-color and
+                                // the lock *directly* here rather than
+                                // going through SetAccentColor, because
+                                // that handler resets the lock to -1.
+                                let app = gio::Settings::new("io.github.gnomex.GnomeX");
+                                if app
+                                    .settings_schema()
+                                    .map(|s| s.has_key("wallpaper-accent-index"))
+                                    .unwrap_or(false)
+                                {
+                                    let _ = app.set_int("wallpaper-accent-index", swatch_index);
+                                }
+                                let iface = gio::Settings::new("org.gnome.desktop.interface");
+                                let _ = iface.set_string("accent-color", &aid);
+                                tracing::info!(
+                                    "accent locked to wallpaper palette[{swatch_index}] → {aid}",
+                                );
                             }
                         });
 
@@ -3039,54 +3086,6 @@ fn build_spin_row(
         .build()
 }
 
-// --- Wallpaper color extraction (Material You style) ---
-
-/// Extract dominant colors from a wallpaper image and map them to GNOME accent colors.
-fn extract_wallpaper_colors(path: &str) -> Result<Vec<(String, String)>, String> {
-    use gnomex_domain::color::{rgb_to_hsv, hsv_to_rgb};
-
-    let pixbuf = gtk::gdk_pixbuf::Pixbuf::from_file_at_scale(path, 64, 64, true)
-        .map_err(|e| format!("failed to load wallpaper: {e}"))?;
-
-    let pixels = pixbuf.pixel_bytes().ok_or("no pixel data")?;
-    let channels = pixbuf.n_channels() as usize;
-    let data = pixels.as_ref();
-
-    let mut color_buckets: std::collections::HashMap<(u16, u8, u8), u32> =
-        std::collections::HashMap::new();
-
-    for chunk in data.chunks_exact(channels) {
-        if channels < 3 { continue; }
-        let (r, g, b) = (chunk[0], chunk[1], chunk[2]);
-        let (h, s, v) = rgb_to_hsv(r, g, b);
-        if s < 15 || v < 25 || v > 240 { continue; }
-        let hue_bin = (h / 10) * 10;
-        let sat_bin = (s / 85).min(2);
-        let val_bin = (v / 85).min(2);
-        *color_buckets.entry((hue_bin, sat_bin, val_bin)).or_default() += 1;
-    }
-
-    let mut buckets: Vec<_> = color_buckets.into_iter().collect();
-    buckets.sort_by(|a, b| b.1.cmp(&a.1));
-
-    let mut results = Vec::new();
-    let mut used_accents = std::collections::HashSet::new();
-
-    for ((hue_bin, sat_bin, val_bin), _) in buckets.iter().take(15) {
-        let h = *hue_bin + 5;
-        let s = (*sat_bin as u16) * 85 + 42;
-        let v = (*val_bin as u16) * 85 + 42;
-        let (r, g, b) = hsv_to_rgb(h, s.min(255) as u8, v.min(255) as u8);
-        let hex = format!("#{:02x}{:02x}{:02x}", r, g, b);
-        let accent_id = closest_accent(r, g, b);
-        if used_accents.contains(&accent_id) { continue; }
-        used_accents.insert(accent_id.clone());
-        results.push((hex, accent_id));
-        if results.len() >= 5 { break; }
-    }
-
-    Ok(results)
-}
 
 /// Parse the `cached-wallpaper-palette` GSetting strv back into the
 /// `Vec<(hex, accent_id)>` shape the UI renders. Silently skips
@@ -3188,24 +3187,4 @@ fn refresh_per_app_listbox(
         row.add_suffix(&remove);
         list.append(&row);
     }
-}
-
-fn closest_accent(r: u8, g: u8, b: u8) -> String {
-    use gnomex_domain::color::color_distance;
-
-    let mut best_id = "blue";
-    let mut best_dist = u32::MAX;
-
-    for &(id, _, hex) in ACCENT_COLORS {
-        let accent = gnomex_domain::HexColor::new(hex)
-            .map(|c| c.to_rgb())
-            .unwrap_or((0, 0, 0));
-        let dist = color_distance((r, g, b), accent);
-        if dist < best_dist {
-            best_dist = dist;
-            best_id = id;
-        }
-    }
-
-    best_id.to_owned()
 }

--- a/data/io.github.gnomex.GnomeX.gschema.xml
+++ b/data/io.github.gnomex.GnomeX.gschema.xml
@@ -245,6 +245,11 @@
       <summary>Cached wallpaper palette</summary>
       <description>Each entry is "HEX:ACCENT_ID". The experienced daemon rewrites this whenever the wallpaper changes, so the UI can show last-known swatches without re-running extraction. Independent of use-wallpaper-accent — that gates whether we also set the accent color automatically.</description>
     </key>
+    <key name="wallpaper-accent-index" type="i">
+      <default>-1</default>
+      <summary>Locked wallpaper palette index</summary>
+      <description>When use-wallpaper-accent is enabled, this governs which swatch of the cached palette drives the accent. -1 (the default) means "use the dominant colour"; 0..N-1 locks to that palette index, so when the daemon re-extracts on a wallpaper change it re-applies the accent at the same index of the new palette rather than the old hex. The UI sets this when the user clicks a wallpaper swatch and resets it to -1 when they click one of the nine stock accent buttons.</description>
+    </key>
     <key name="wallpaper-slideshow-name" type="s">
       <default>'gnome-x-slideshow'</default>
       <summary>Last-configured wallpaper slideshow name (GXF-072)</summary>


### PR DESCRIPTION
## Summary

Two fixes, one PR — they share the new shared wallpaper-palette module.

1. **Extraction regression (slideshow XML).** The GXF-072 slideshow feature wrote a GNOME `.xml` manifest to `picture-uri`. The daemon's `extract_wallpaper_palette` and the UI's `extract_wallpaper_colors` both called `Pixbuf::from_file_at_scale` directly on that URI, silently failing because pixbuf can't parse XML. Users who enabled a slideshow lost all wallpaper swatches.
2. **Palette-index tracking.** Previously the daemon on wallpaper-change re-extracted the palette but always used the *dominant* colour. The user explicitly asked: when they click, say, the 3rd swatch, the daemon should remember that and on the next wallpaper apply the 3rd swatch of the *new* palette — not the old hex, which no longer exists.

## How it works

**New shared module `gnomex-infra::wallpaper_palette`:**

| Function | Purpose |
|---|---|
| `resolve_wallpaper_image(uri)` | plain image → the image itself; `.xml` → the `<static>` entry that should be showing right now (walks the cycle modulo total duration) |
| `extract_palette(path)` | the single source of truth for the HSV-bucket extractor; used by both daemon and UI |
| `locked_accent(palette, idx)` | returns `palette[idx].accent_id` when in range, `palette[0]` on -1 or out-of-range, `None` on empty |
| `encode_palette` / `decode_palette` | one encoding of the `cached-wallpaper-palette` strv |

**Daemon wallpaper watcher rewritten.** One `reapply` closure, three triggers:
- `picture-uri` change (user picked a new wallpaper or slideshow XML)
- `wallpaper-accent-index` change (user clicked a swatch — re-evaluate immediately so their click takes effect without waiting for the next wallpaper change)
- **New slideshow tick** — `glib::timeout_add_seconds_local(wallpaper-slideshow-interval, …)` installed whenever `picture-uri` points to a `.xml`, torn down otherwise. This is the missing piece: GNOME cycles slideshow images internally without re-firing `connect_changed`, so without the tick the palette stays frozen on whichever image was on screen when the slideshow started.

**UI swatch click** now writes `accent-color` AND `wallpaper-accent-index = N` *directly* (bypassing the `SetAccentColor` message so the stock-accent reset path doesn't clobber the lock we just set). Stock accent pickers reset the lock to -1.

## Schema

New key:

```xml
<key name="wallpaper-accent-index" type="i">
  <default>-1</default>
  ...
</key>
```

-1 = "use dominant"; 0..N-1 = "use palette slot N".

## Test plan

- [x] `cargo test --workspace` passes.
- [x] `cargo test -p gnomex-infra --lib wallpaper_palette` — 11/11. Covers: XML slideshow resolution (t=0 picks first, t=12 wraps to second, relative `<file>` paths resolve against base dir), unescaping, plain-path passthrough, `locked_accent` fallback matrix (in-range → that, -1 → dominant, out-of-range → dominant, empty → None), encode/decode round-trip.
- [x] `glib-compile-schemas --strict --dry-run data/` validates the new key.
- [x] `cargo build -p gnomex-ui -p gnomex-daemon -p gnomex-cli` clean.
- [x] Manually verify: set a single image wallpaper, click swatch #3 → accent changes. Change wallpaper → the 3rd swatch of the new palette becomes the accent.
- [x] Manually verify: configure a slideshow with 3 pictures at 60 s intervals, wait 60 s past a transition → daemon logs "slideshow tick" and cached-wallpaper-palette changes.
- [x] Manually verify: click any stock accent (`blue`, `teal`, …) → subsequent wallpaper change picks the dominant again.